### PR TITLE
Fix context menu registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,43 +35,11 @@
         {
           "when": "editorLangId == dockerfile",
           "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == Dockerfile.debug",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == dockerfile.debug",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == Dockerfile.Debug",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == dockerfile.Debug",
-          "command": "azure-iot-edge.buildDockerImage"
         }
       ],
       "explorer/context": [
         {
           "when": "resourceLangId == dockerfile",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == Dockerfile.debug",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == dockerfile.debug",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == Dockerfile.Debug",
-          "command": "azure-iot-edge.buildDockerImage"
-        },
-        {
-          "when": "resourceFilename == dockerfile.Debug",
           "command": "azure-iot-edge.buildDockerImage"
         },
         {
@@ -113,6 +81,18 @@
         }
       }
     },
+    "languages": [
+      {
+        "id": "dockerfile",
+        "aliases": [
+          "Dockerfile"
+        ],
+        "filenamePatterns": [
+          "dockerfile*",
+          "Dockerfile*"
+        ]
+      }
+    ],
     "debuggers": [
       {
         "type": "edge-coreclr",


### PR DESCRIPTION
Fix context menu registration by identifying "dockerfile*" and "Dockerfile*" as Dockerfile.

There are two issues with the previous implementation:
1. When vscode-docker extension is installed, files with name "Dockerfile.Debug" will have duplicate context menus.
2. When the Dockerfile is named like "Dockerfile.Debug.1", there will not be a context menu.