### PR TITLE
Add support for Docker build arguments.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,6 +1597,11 @@
         "readable-stream": "2.3.5"
       }
     },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
   "dependencies": {
     "fs-extra": "^4.0.2",
     "jsonc-parser": "^1.0.1",
+    "lodash": "^4.17.5",
     "strip-json-comments": "^2.0.1",
     "vscode-extension-telemetry": "0.0.8"
   },

--- a/src/common/jsonCompletionItemProvider.ts
+++ b/src/common/jsonCompletionItemProvider.ts
@@ -70,7 +70,7 @@ export class JsonCompletionItemProvider implements vscode.CompletionItemProvider
         const imageToDockerfileMap: Map<string, string> = new Map();
 
         try {
-            await Utility.setSlnModulesMap(path.dirname(templateUri.fsPath), moduleToImageMap, imageToDockerfileMap);
+            await Utility.setSlnModulesMap(path.dirname(templateUri.fsPath), moduleToImageMap, imageToDockerfileMap, []);
 
             const placeholders: string[] = [];
             for (const module of moduleToImageMap.keys()) {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -258,7 +258,7 @@ export class Utility {
         if (await fse.pathExists(moduleFile)) {
             const module = await Utility.readJsonAndExpandEnv(moduleFile);
             const platformKeys: string[] = Object.keys(module.image.tag.platforms);
-            const dockerBuildArgs: string[] = _.get(module, 'image.docker.build', []);
+            const dockerBuildArgs: string[] = _.get(module, "image.docker.build", []);
             const repo: string = module.image.repository;
             const version: string = module.image.tag.version;
             imageBuildArgs.push(...dockerBuildArgs);

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -130,7 +130,7 @@ export class ContainerManager {
     }
 
     private constructBuildCmd(dockerfilePath: string, imageName: string, contextDir: string, args: string[]): string {
-        return `docker build --rm ${args.join(' ')} -f \"${Utility.adjustFilePath(dockerfilePath)}\" -t ${imageName} \"${Utility.adjustFilePath(contextDir)}\"`;
+        return `docker build --rm ${args.join(" ")} -f \"${Utility.adjustFilePath(dockerfilePath)}\" -t ${imageName} \"${Utility.adjustFilePath(contextDir)}\"`;
     }
 
     private constructPushCmd(imageName: string) {


### PR DESCRIPTION
Fixes #95 (Add support for custom Docker arguments in module.json)

Add a `docker.build` section to the modules.json to support an arbitrary array of custom Docker build arguments.  A sample module.json:

```
{
    "$schema-version": "0.0.1",
    "description": "",
    "image": {
        "repository": "myrepo/samplemodule",
        "tag": {
            "version": "1.0",
            "platforms": {
                "arm64v8": "./Dockerfile.arm64v8"
            }
        },
        "docker": {
            "build": [
                "--add-host=github.com:192.30.255.112",
                "--add-host=ports.ubuntu.com:91.189.88.150"
            ]
        }
    },
    "language": "cplusplus"
}
```