### PR TITLE
Add ACR credentials in IoT Edge runtime instead of docker login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -748,7 +748,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -27,6 +27,10 @@ export class Utility {
         return true;
     }
 
+    public static adjustTerminalCommand(command: string): string {
+        return (os.platform() === "linux" || os.platform() === "darwin") ? `sudo ${command}` : command;
+    }
+
     public static adjustFilePath(filePath: string): string {
         if (os.platform() === "win32") {
             const windowsShell = vscode.workspace.getConfiguration("terminal").get<string>("integrated.shell.windows");

--- a/src/container/acrManager.ts
+++ b/src/container/acrManager.ts
@@ -203,12 +203,12 @@ export class AcrManager {
             const adminUserEnabled: boolean = registry.adminUserEnabled;
             const registryUrl: string = registry.loginServer;
             const loginMessage = adminUserEnabled ? `Looks like the registry "${registryUrl}" has admin user enabled. `
-                + `Would you like to run "docker login" with the admin user credentials?`
+                + `Would you like to add the admin user credentials to IoT Edge runtime?`
                 : `Looks like the registry "${registryUrl}" does not have admin user enabled. `
-                + `Would you like to enable admin user and run "docker login" with the admin user credentials?`;
+                + `Would you like to enable admin user and add the admin user credentials to IoT Edge runtime?`;
             const option: string = await vscode.window.showInformationMessage(loginMessage, "Yes", "No");
             if (option === "Yes") {
-                vscode.window.withProgress({ title: `Logging in to registry "${registryUrl}"...`, location: vscode.ProgressLocation.Window }, async (progress) => {
+                vscode.window.withProgress({ title: `Adding registry "${registryUrl}" credentials to IoT Edge runtime...`, location: vscode.ProgressLocation.Window }, async (progress) => {
                     const registryName: string = registry.name;
                     const resourceGroup: string = registry.id.slice(registry.id.toLowerCase().search("resourcegroups/") + "resourcegroups/".length, registry.id.toLowerCase().search("/providers/"));
                     const client = new ContainerRegistryManagementClient(
@@ -226,7 +226,7 @@ export class AcrManager {
                     const username: string = creds.username;
                     const password: string = creds.passwords[0].value;
 
-                    Executor.runInTerminal(`docker login -u ${username} -p ${password} ${registryUrl}`);
+                    Executor.runInTerminal(`iotedgectl login --address ${registryUrl} --username ${username} --password ${password}`);
                 });
             }
         } catch (error) {

--- a/src/container/acrManager.ts
+++ b/src/container/acrManager.ts
@@ -9,6 +9,7 @@ import * as request from "request-promise";
 import * as vscode from "vscode";
 import { Executor } from "../common/executor";
 import { UserCancelledError } from "../common/UserCancelledError";
+import { Utility } from "../common/utility";
 import { AcrRegistryQuickPickItem } from "../container/models/AcrRegistryQuickPickItem";
 import { AzureAccount, AzureSession, AzureSubscription } from "../typings/azure-account.api";
 
@@ -226,7 +227,7 @@ export class AcrManager {
                     const username: string = creds.username;
                     const password: string = creds.passwords[0].value;
 
-                    Executor.runInTerminal(`iotedgectl login --address ${registryUrl} --username ${username} --password ${password}`);
+                    Executor.runInTerminal(Utility.adjustTerminalCommand(`iotedgectl login --address ${registryUrl} --username ${username} --password ${password}`));
                 });
             }
         } catch (error) {


### PR DESCRIPTION
Per my test, you have to add the ACR credentials in IoT Edge runtime so that the Edge runtime can pull the images; `docker login` does not work.