### PR TITLE
Avoid creating shell when possible

### DIFF
--- a/src/common/executor.ts
+++ b/src/common/executor.ts
@@ -30,6 +30,7 @@ export class Executor {
                                    options: SpawnOptions, ...args: string[]): Promise<void> {
         await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
             outputPane.show();
+            outputPane.appendLine(`Executing ${command} ${args.join(" ")}`);
             let stderr: string = "";
             const p: ChildProcess = spawn(command, args, options);
             p.stdout.on("data", (data: string | Buffer): void =>

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -199,24 +199,24 @@ export class EdgeManager {
         // TODO command to create module;
         switch (template) {
             case Constants.LANGUAGE_CSHARP:
-                await Executor.executeCMD(outputChannel, "dotnet", { shell: true }, "new -i Microsoft.Azure.IoT.Edge.Module");
-                await Executor.executeCMD(outputChannel, "dotnet", { cwd: `${parent}`, shell: true }, `new aziotedgemodule -n "${name}" -r ${repositoryName}`);
+                await Executor.executeCMD(outputChannel, "dotnet", {}, ..."new -i Microsoft.Azure.IoT.Edge.Module".split(" "));
+                await Executor.executeCMD(outputChannel, "dotnet", { cwd: `${parent}` }, ...`new aziotedgemodule -n ${name} -r ${repositoryName}`.split(" "));
                 break;
             case Constants.CSHARP_FUNCTION:
-                await Executor.executeCMD(outputChannel, "dotnet", { shell: true }, "new -i Microsoft.Azure.IoT.Edge.Function");
-                await Executor.executeCMD(outputChannel, "dotnet", { cwd: `${parent}`, shell: true }, `new aziotedgefunction -n "${name}" -r ${repositoryName}`);
+                await Executor.executeCMD(outputChannel, "dotnet", {}, ..."new -i Microsoft.Azure.IoT.Edge.Function".split(" "));
+                await Executor.executeCMD(outputChannel, "dotnet", { cwd: `${parent}` }, ...`new aziotedgefunction -n ${name} -r ${repositoryName}`.split(" "));
                 break;
             case Constants.LANGUAGE_PYTHON:
                 const gitHubSource = "https://github.com/Azure/cookiecutter-azure-iot-edge-module";
                 const branch = "master";
                 await Executor.executeCMD(outputChannel,
                     "cookiecutter",
-                    { cwd: `${parent}`, shell: true },
-                    `--no-input ${gitHubSource} module_name=${name} image_repository=${repositoryName} --checkout ${branch}`);
+                    { cwd: `${parent}` },
+                    ...`--no-input ${gitHubSource} module_name=${name} image_repository=${repositoryName} --checkout ${branch}`.split(" "));
                 break;
             case Constants.LANGUAGE_NODE:
-                await Executor.executeCMD(outputChannel, "npm", { shell: true }, "i -g generator-azure-iot-edge-module");
-                await Executor.executeCMD(outputChannel, "yo", { cwd: `${parent}`, shell: true }, `azure-iot-edge-module -n "${name}" -r ${repositoryName}`);
+                await Executor.executeCMD(outputChannel, "npm", { shell: true }, ..."i -g generator-azure-iot-edge-module".split(" "));
+                await Executor.executeCMD(outputChannel, "yo", { cwd: `${parent}`, shell: true }, ...`azure-iot-edge-module -n ${name} -r ${repositoryName}`.split(" "));
                 break;
             default:
                 break;


### PR DESCRIPTION
Except that `npm` is actually the `npm.cmd` script on Windows, `dotnet`, `cookiecutter` both do not rely on a shell to execute. Not creating a shell will improve the performance.

This PR also adds a line of output showing the command currently being executed.