### PR TITLE
Add credential block into deployment template

### DIFF
--- a/assets/solution/deployment.template.json
+++ b/assets/solution/deployment.template.json
@@ -8,7 +8,7 @@
           "settings": {
             "minDockerVersion": "v1.25",
             "loggingOptions": "",
-            "registryCredentials": %REGISTRY%
+            "registryCredentials": "%REGISTRY%"
           }
         },
         "systemModules": {

--- a/assets/solution/deployment.template.json
+++ b/assets/solution/deployment.template.json
@@ -8,13 +8,7 @@
           "settings": {
             "minDockerVersion": "v1.25",
             "loggingOptions": "",
-            "registryCredentials":{
-              "EdgeShared": {
-                  "username":"EdgeShared",
-                  "password":"<password>",
-                  "address":"edgeshared.azurecr.io"
-              }
-            }
+            "registryCredentials": %REGISTRY%
           }
         },
         "systemModules": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-edge",
   "displayName": "Azure IoT Edge",
   "description": "Develop, deploy, debug, and manage your IoT Edge solution",
-  "version": "0.5.0-private3",
+  "version": "0.5.0-private4",
   "publisher": "vsciot-vscode",
   "aiKey": "95b20d64-f54f-4de3-8ad5-165a75a6c6fe",
   "icon": "logo.png",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -86,6 +86,8 @@ export class Constants {
     public static routeSnippetLabel = "edgeRoute";
     public static routeSnippetDetail = "Route for the Edge Hub. Route name is used as the key for the route. To delete a route, set the route name as null";
     public static platformModuleManifestJsonPath = ["image", "tag", "platforms", "*"];
+    public static setRegistryEnvNotification = "Please set container registry credentials to .env file";
+    public static acrEnvSet = "ACR credentials have been set in .env file";
     public static envFile = ".env";
 }
 

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -365,8 +365,8 @@ export class Utility {
     }
 
     public static getRegistryAddress(repositoryName: string) {
-        const DefaultHostname = "docker.io";
-        const LegacyDefaultHostname = "index.docker.io";
+        const defaultHostname = "docker.io";
+        const legacyDefaultHostname = "index.docker.io";
         const index = repositoryName.indexOf("/");
 
         let name: string;
@@ -377,13 +377,13 @@ export class Utility {
         if (name === undefined
             || (name !== "localhost" && (!(name.includes(".") || name.includes(":"))))
         ) {
-            hostname = DefaultHostname;
+            hostname = defaultHostname;
         } else {
             hostname = name;
         }
 
-        if (hostname === LegacyDefaultHostname) {
-            hostname = DefaultHostname;
+        if (hostname === legacyDefaultHostname) {
+            hostname = defaultHostname;
         }
 
         return hostname;

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -372,7 +372,7 @@ export class Utility {
         let name: string;
         let hostname: string;
         if (index !== -1) {
-            name = repositoryName.substring(0, index);
+            name = (repositoryName.substring(0, index)).toLocaleLowerCase();
         }
         if (name === undefined
             || (name !== "localhost" && (!(name.includes(".") || name.includes(":"))))

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -147,8 +147,9 @@ export class Utility {
         const srcFile: string = path.join(srcPath, fileName);
         const srcFileContent: string = await fse.readFile(srcFile, "utf8");
         const fileContentGenerated: string = Utility.replaceAll(srcFileContent, mapObj);
+        const jsonFormat = JSON.parse(fileContentGenerated);
         const targetFile: string = path.join(targetPath, fileName);
-        await fse.writeFile(targetFile, fileContentGenerated, { encoding: "utf8" });
+        await fse.writeFile(targetFile, JSON.stringify(jsonFormat, null, 2), { encoding: "utf8" });
     }
 
     public static replaceAll(str: string, mapObj: Map<string, string>, caseInSensitive: boolean = false): string {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -344,6 +344,51 @@ export class Utility {
         } catch (error) {}
     }
 
+    public static getAddressKey(address: string, keySet: Set<string>): string {
+        let key = address;
+        let index = address.indexOf(".");
+        if (index === -1) {
+            index = address.indexOf(":");
+        }
+        if (index !== -1) {
+            key = address.substring(0, index);
+        }
+
+        let suffix = 1;
+        const keyPrefix: string = key;
+        while (keySet.has(key)) {
+            key = `${keyPrefix}_${suffix}`;
+            suffix += 1;
+        }
+
+        return key;
+    }
+
+    public static getRegistryAddress(repositoryName: string) {
+        const DefaultHostname = "docker.io";
+        const LegacyDefaultHostname = "index.docker.io";
+        const index = repositoryName.indexOf("/");
+
+        let name: string;
+        let hostname: string;
+        if (index !== -1) {
+            name = repositoryName.substring(0, index);
+        }
+        if (name === undefined
+            || (name !== "localhost" && (!(name.includes(".") || name.includes(":"))))
+        ) {
+            hostname = DefaultHostname;
+        } else {
+            hostname = name;
+        }
+
+        if (hostname === LegacyDefaultHostname) {
+            hostname = DefaultHostname;
+        }
+
+        return hostname;
+    }
+
     private static getLocalRegistryState(): ContainerState {
         try {
             const isRunning = Executor.execSync("docker inspect registry --format='{{.State.Running}}'");

--- a/src/container/acrManager.ts
+++ b/src/container/acrManager.ts
@@ -50,11 +50,10 @@ export class AcrManager {
 
         if (await this.azureAccount.waitForLogin()) {
             const registriesItems = await this.loadAcrRegistryItems();
-            for (let idx = 0; idx < registriesItems.length; idx++) {
-                const registry = registriesItems[idx].registry;
-
+            for (const registryItem of registriesItems) {
+                const registry = registryItem.registry;
                 if (registry.loginServer === address && registry.adminUserEnabled) {
-                    const azureSubscription = registriesItems[idx].azureSubscription;
+                    const azureSubscription = registryItem.azureSubscription;
                     const registryName: string = registry.name;
                     const resourceGroup: string = registry.id.slice(registry.id.toLowerCase().search("resourcegroups/") + "resourcegroups/".length, registry.id.toLowerCase().search("/providers/"));
                     const client = new ContainerRegistryManagementClient(
@@ -64,7 +63,7 @@ export class AcrManager {
                     const creds: RegistryListCredentialsResult = await client.registries.listCredentials(resourceGroup, registryName);
                     username = creds.username;
                     password = creds.passwords[0].value;
-                    break;                
+                    break;
                 }
             }
         }

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -160,25 +160,27 @@ export class EdgeManager {
             return;
         }
 
-        const folderPath = folder.uri.fsPath;
-        if (folder) {
-            const deploymentTemplate = path.join(folderPath, Constants.deploymentTemplate);
-            const envFile = path.join(folderPath, Constants.envFile);
-            if (await fse.exists(deploymentTemplate)) {
-                const templateJson = await fse.readJson(deploymentTemplate);
-                const runtimeSettings = templateJson.moduleContent.$edgeAgent["properties.desired"].runtime.settings;
-                const registries = runtimeSettings.registryCredentials;
-                if (registries) {
-                    await Utility.loadEnv(envFile);
-                    const expanded = Utility.expandEnv(JSON.stringify(registries, null, 2));
-                    const pattern: RegExp = new RegExp(/\$([a-zA-Z0-9_]+)|\${([a-zA-Z0-9_]+)}/g);
-                    const matchArr = expanded.match(pattern);
-                    if (matchArr && matchArr.length > 0) {
-                        await this.askEditEnv(envFile);
+        try {
+            const folderPath = folder.uri.fsPath;
+            if (folder) {
+                const deploymentTemplate = path.join(folderPath, Constants.deploymentTemplate);
+                const envFile = path.join(folderPath, Constants.envFile);
+                if (await fse.exists(deploymentTemplate)) {
+                    const templateJson = await fse.readJson(deploymentTemplate);
+                    const runtimeSettings = templateJson.moduleContent.$edgeAgent["properties.desired"].runtime.settings;
+                    const registries = runtimeSettings.registryCredentials;
+                    if (registries) {
+                        await Utility.loadEnv(envFile);
+                        const expanded = Utility.expandEnv(JSON.stringify(registries, null, 2));
+                        const pattern: RegExp = new RegExp(/\$([a-zA-Z0-9_]+)|\${([a-zA-Z0-9_]+)}/g);
+                        const matchArr = expanded.match(pattern);
+                        if (matchArr && matchArr.length > 0) {
+                            await this.askEditEnv(envFile);
+                        }
                     }
                 }
             }
-        }
+        } catch (err) {}
     }
 
     // TODO: The command is temperory for migration stage, will be removed later.

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -50,12 +50,12 @@ export class EdgeManager {
         const registries = {
             EdgeShared: {
                 username: "EdgeShared",
-                password: "$CONTAINER_REGISTRY_USERNAME_edgeshared",
+                password: "$CONTAINER_REGISTRY_PASSWORD_edgeshared",
                 address: "edgeshared.azurecr.io",
             },
         };
         await fse.ensureFile(envFilePath);
-        await fse.appendFile(envFilePath, "CONTAINER_REGISTRY_USERNAME_edgeshared=\n", { encoding: "utf8" });
+        await fse.appendFile(envFilePath, "CONTAINER_REGISTRY_PASSWORD_edgeshared=\n", { encoding: "utf8" });
 
         const result = await this.updateRegistrySettings(registryAddress, registries, envFilePath);
         const mapObj: Map<string, string> = new Map<string, string>();

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -388,7 +388,6 @@ export class EdgeManager {
                 registries = {};
             }
             registries[addressKey] = JSON.parse(newRegistry);
-            return {registries, usernameEnv, passwordEnv};
         }
         return {registries, usernameEnv, passwordEnv};
     }

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -371,10 +371,15 @@ export class EdgeManager {
     }
 
     private async updateRegistrySettings(address: string, registries: any, envFile: string): Promise<{registries: string, usernameEnv: string, passwordEnv: string}> {
-        await Utility.loadEnv(envFile);
-        const {exists, keySet} = this.checkAddressExist(address, registries);
         let usernameEnv;
         let passwordEnv;
+        const lowerCase = address.toLowerCase();
+        if (lowerCase === "localhost" || lowerCase.startsWith("localhost:")) {
+            return {registries, usernameEnv, passwordEnv};
+        }
+        await Utility.loadEnv(envFile);
+        const {exists, keySet} = this.checkAddressExist(address, registries);
+
         if (!exists) {
             const addressKey = Utility.getAddressKey(address, keySet);
             usernameEnv = `CONTAINER_REGISTRY_USERNAME_${addressKey}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const folders = vscode.workspace.workspaceFolders;
     if (folders && folders.length > 0) {
-        folders.forEach(async (value) => await edgeManager.checkRegistryEnv(value));
+        folders.forEach((value) => edgeManager.checkRegistryEnv(value));
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,6 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(diagCollection);
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((event) => configDiagnosticProvider.updateDiagnostics(event.document, diagCollection)));
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => configDiagnosticProvider.updateDiagnostics(document, diagCollection)));
-    //context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => checkRegistryEnv(event.added, edgeManager.checkRegistryEnv)));
 
     const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(Constants.edgeDisplayName);
     context.subscriptions.push(outputChannel);
@@ -91,7 +90,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const folders = vscode.workspace.workspaceFolders;
     if (folders && folders.length > 0) {
-        folders.forEach(async value => await edgeManager.checkRegistryEnv(value));
+        folders.forEach(async (value) => await edgeManager.checkRegistryEnv(value));
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(diagCollection);
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((event) => configDiagnosticProvider.updateDiagnostics(event.document, diagCollection)));
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => configDiagnosticProvider.updateDiagnostics(document, diagCollection)));
+    //context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => checkRegistryEnv(event.added, edgeManager.checkRegistryEnv)));
 
     const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(Constants.edgeDisplayName);
     context.subscriptions.push(outputChannel);
@@ -87,6 +88,11 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {
         Executor.onDidCloseTerminal(closedTerminal);
     }));
+
+    const folders = vscode.workspace.workspaceFolders;
+    if (folders && folders.length > 0) {
+        folders.forEach(async value => await edgeManager.checkRegistryEnv(value));
+    }
 }
 
 function initCommand(context: vscode.ExtensionContext,

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -107,6 +107,9 @@ suite("utility tests", () => {
     registry = Utility.getRegistryAddress("localhost/test");
     assert.equal(registry, "localhost");
 
+    registry = Utility.getRegistryAddress("LOCALHOST/test");
+    assert.equal(registry, "localhost");
+
     registry = Utility.getRegistryAddress("a.azurecr.io/test");
     assert.equal(registry, "a.azurecr.io");
 

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -82,4 +82,38 @@ suite("utility tests", () => {
                           }';
     assert.equal(generated, expected);
   }).timeout(60 * 1000);
+
+  test("getAddressKey", () => {
+    const keySet = new Set([]);
+    let key = Utility.getAddressKey("localhost:5000", new Set([]));
+    assert.equal(key, "localhost");
+    keySet.add("localhost");
+    key = Utility.getAddressKey("localhost:5000", keySet);
+    assert.equal(key, "localhost_1");
+    keySet.add("localhost_1");
+    key = Utility.getAddressKey("localhost", keySet);
+    assert.equal(key, "localhost_2");
+    key = Utility.getAddressKey("a.azurecr.io", keySet);
+    assert.equal(key, "a");
+    keySet.add("a");
+    key = Utility.getAddressKey("a", keySet);
+    assert.equal(key, "a_1");
+  });
+
+  test("getRegistryAddress", () => {
+    let registry = Utility.getRegistryAddress("localhost:5000/test");
+    assert.equal(registry, "localhost:5000");
+
+    registry = Utility.getRegistryAddress("localhost/test");
+    assert.equal(registry, "localhost");
+
+    registry = Utility.getRegistryAddress("a.azurecr.io/test");
+    assert.equal(registry, "a.azurecr.io");
+
+    registry = Utility.getRegistryAddress("microsoft/tet");
+    assert.equal(registry, "docker.io");
+
+    registry = Utility.getRegistryAddress("python");
+    assert.equal(registry, "docker.io");
+  });
 });


### PR DESCRIPTION
Now when adding a module, the registry information (address, username, password) will be inserted into deployment template through environment variables.
If the registry is ACR and could get credential from the current user. The credentials will be populated into .env file automatically. 
Other cases placeholders are added into .env file. And there are message ask user to edit env.