### PR TITLE
add support for docker build context path

### DIFF
--- a/src/common/buildSettings.ts
+++ b/src/common/buildSettings.ts
@@ -1,0 +1,11 @@
+export class BuildSettings {
+    public readonly options?: string[];
+    public readonly contextPath: string;
+    public readonly dockerFile: string;
+
+    constructor(dockerFile: string, contextPath: string, options?: string[]) {
+        this.dockerFile = dockerFile;
+        this.contextPath = contextPath;
+        this.options = options;
+    }
+}

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -97,6 +97,7 @@ export class Constants {
     public static envFile = ".env";
     public static inputNamePrompt = "Provide the input names of the module to handle message";
     public static inputNamePattern = "input1,input2,input3";
+    public static moduleSchemaVersion = "$schema-version";
 }
 
 export enum ContainerState {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -288,7 +288,7 @@ export class Utility {
         const moduleFile = path.join(modulePath, Constants.moduleManifest);
         const name: string = path.basename(modulePath);
         if (await fse.pathExists(moduleFile)) {
-            const module = await Utility.readJsonAndExpandEnv(moduleFile, "$schema-version");
+            const module = await Utility.readJsonAndExpandEnv(moduleFile, Constants.moduleSchemaVersion);
             const platformKeys: string[] = Object.keys(module.image.tag.platforms);
             const repo: string = module.image.repository;
             const version: string = module.image.tag.version;

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -278,7 +278,7 @@ export class Utility {
         buildOptions?: string[],
         contextPath?: string): BuildSettings {
         const optionArray = (buildOptions && buildOptions instanceof Array) ? buildOptions : undefined;
-        const context = contextPath ? path.join(modulePath, contextPath) : path.dirname(dockerFilePath);
+        const context = contextPath ? path.resolve(modulePath, contextPath) : path.dirname(dockerFilePath);
         return new BuildSettings(dockerFilePath, context, optionArray);
     }
 
@@ -297,7 +297,7 @@ export class Utility {
                 const image: string = Utility.getImage(repo, version, platform);
                 moduleToImageMap.set(moduleKey, image);
                 if (imageToBuildSettings !== undefined) {
-                    const dockerFilePath = path.join(modulePath, module.image.tag.platforms[platform]);
+                    const dockerFilePath = path.resolve(modulePath, module.image.tag.platforms[platform]);
                     imageToBuildSettings.set(
                         image,
                         Utility.getBuildSettings(modulePath,

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -5,7 +5,7 @@
 import * as fse from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
-import {BuildSettings} from "../common/buildSettings";
+import { BuildSettings } from "../common/buildSettings";
 import { Constants } from "../common/constants";
 import { Executor } from "../common/executor";
 import { Utility } from "../common/utility";
@@ -22,7 +22,7 @@ export class ContainerManager {
             const platforms = moduleConfig.image.tag.platforms;
             const platform = await vscode.window.showQuickPick(Object.keys(platforms), { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
             if (platform) {
-                const dockerfilePath = path.join(directory, platforms[platform]);
+                const dockerfilePath = path.resolve(directory, platforms[platform]);
                 const imageName = Utility.getImage(moduleConfig.image.repository, moduleConfig.image.tag.version, platform);
                 const buildSettings = Utility.getBuildSettings(directory, dockerfilePath, moduleConfig.image.buildOptions, moduleConfig.image.contextPath);
                 const buildCommand = this.constructBuildCmd(imageName, buildSettings);

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -18,7 +18,7 @@ export class ContainerManager {
         if (moduleConfigFilePath) {
             const directory = path.dirname(moduleConfigFilePath);
             await Utility.loadEnv(path.join(directory, "..", "..", Constants.envFile));
-            const moduleConfig = await Utility.readJsonAndExpandEnv(moduleConfigFilePath, "$schema-version");
+            const moduleConfig = await Utility.readJsonAndExpandEnv(moduleConfigFilePath, Constants.moduleSchemaVersion);
             const platforms = moduleConfig.image.tag.platforms;
             const platform = await vscode.window.showQuickPick(Object.keys(platforms), { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
             if (platform) {

--- a/src/intelliSense/configCompletionItemProvider.ts
+++ b/src/intelliSense/configCompletionItemProvider.ts
@@ -71,10 +71,9 @@ export class ConfigCompletionItemProvider implements vscode.CompletionItemProvid
 
     private async getSlnImgPlaceholders(templateUri: vscode.Uri): Promise<string[]> {
         const moduleToImageMap: Map<string, string> = new Map();
-        const imageToDockerfileMap: Map<string, string> = new Map();
 
         try {
-            await Utility.setSlnModulesMap(path.dirname(templateUri.fsPath), moduleToImageMap, imageToDockerfileMap);
+            await Utility.setSlnModulesMap(path.dirname(templateUri.fsPath), moduleToImageMap);
 
             const placeholders: string[] = [];
             for (const module of moduleToImageMap.keys()) {

--- a/src/intelliSense/configDiagnosticProvider.ts
+++ b/src/intelliSense/configDiagnosticProvider.ts
@@ -31,10 +31,9 @@ export class ConfigDiagnosticProvider {
         const diags: vscode.Diagnostic[] = [];
 
         const moduleToImageMap: Map<string, string> = new Map();
-        const imageToDockerfileMap: Map<string, string> = new Map();
 
         try {
-            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap, imageToDockerfileMap);
+            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap);
 
             const rootNode: parser.Node = parser.parseTree(document.getText());
             const moduleJsonPath: string[] = Constants.moduleDeploymentManifestJsonPath.slice(0, - 1); // remove the trailing "*" element

--- a/src/intelliSense/intelliSenseUtility.ts
+++ b/src/intelliSense/intelliSenseUtility.ts
@@ -5,6 +5,7 @@
 import * as parser from "jsonc-parser/lib/umd/main";
 import * as path from "path";
 import * as vscode from "vscode";
+import { BuildSettings } from "../common/buildSettings";
 import { Constants } from "../common/constants";
 import { Utility } from "../common/utility";
 
@@ -20,16 +21,16 @@ export class IntelliSenseUtility {
 
         if (IntelliSenseUtility.locationMatch(location, Constants.imgDeploymentManifestJsonPath)) {
             const moduleToImageMap: Map<string, string> = new Map();
-            const imageToDockerfileMap: Map<string, string> = new Map();
+            const imageToBuildSettingsMap: Map<string, BuildSettings> = new Map();
 
             try {
-                await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap, imageToDockerfileMap);
+                await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap, imageToBuildSettingsMap);
 
                 const node: parser.Node = location.previousNode;
                 const imagePlaceholder: string = Utility.unwrapImagePlaceholder(node.value);
                 const image = moduleToImageMap.get(imagePlaceholder);
                 if (image) {
-                    const dockerfile: string = imageToDockerfileMap.get(image);
+                    const dockerfile: string = imageToBuildSettingsMap.get(image).dockerFile;
                     const range: vscode.Range = IntelliSenseUtility.getNodeRange(document, node);
                     return {dockerfile, range};
                 }

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -3,6 +3,7 @@ import * as fse from "fs-extra";
 import * as path from "path";
 import { Constants } from "../src/common/constants";
 import { Utility } from "../src/common/utility";
+import { BuildSettings } from "../src/common/buildSettings";
 
 suite("utility tests", () => {
   test("expandEnv", async () => {
@@ -42,13 +43,11 @@ suite("utility tests", () => {
   test("setModuleMap", async () => {
     const moduleDir = path.resolve(__dirname, "../../testResources/module1");
     const moduleToImageMap: Map<string, string> = new Map();
-    const imageToDockerfileMap: Map<string, string> = new Map();
-    const imageToBuildOptions: Map<string, string[]> = new Map();
-    await Utility.setModuleMap(moduleDir, moduleToImageMap, imageToDockerfileMap, imageToBuildOptions);
+    const imageToBuildSettings: Map<string, BuildSettings> = new Map();
+    await Utility.setModuleMap(moduleDir, moduleToImageMap, imageToBuildSettings);
     assert.equal(moduleToImageMap.size, 4);
-    assert.equal(imageToDockerfileMap.size, 4);
-    assert.equal(imageToBuildOptions.size, 4);
-    assert.equal(imageToBuildOptions.get("localhost:5000/samplemodule:0.0.1-amd64").length, 8);
+    assert.equal(imageToBuildSettings.size, 4);
+    assert.equal(imageToBuildSettings.get("localhost:5000/samplemodule:0.0.1-amd64").options.length, 8);
   }).timeout(60 * 1000);
 
   test("replaceAll", async () => {


### PR DESCRIPTION
1. now user could specify the docker build context path at "module.json" at "image/contextPath". The path value could be absolute or relative to the current "module.json"
2. Also refactored the code to define the class "buildsettings"
3. @LazarusX some change in intellisense, please have a check