### PR TITLE
Handle createOptions with line breaks and spaces

### DIFF
--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -15,7 +15,6 @@ import { Constants, ContainerState } from "./constants";
 import { Executor } from "./executor";
 import { TelemetryClient } from "./telemetryClient";
 import { UserCancelledError } from "./UserCancelledError";
-import { create } from "domain";
 
 export class Utility {
     public static getConfiguration(): vscode.WorkspaceConfiguration {

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -84,7 +84,7 @@ suite("utility tests", () => {
       createOptions: createOptionsVal,
     };
 
-    settings = Utility.serializeCreateOptions(settings, createOptionsVal);
+    settings = Utility.serializeCreateOptions("testModule", settings, createOptionsVal);
     const outStr = JSON.stringify(settings);
 
     const expected = "{\"image\":\"test\",\"createOptions\":\"{\\\"Env\\\":[\\\"k1=v1\\\",\\\"k2=v2\\\",\\\"k3=v3\\\"],"
@@ -112,9 +112,23 @@ suite("utility tests", () => {
       createOptions: createOptionsVal,
     };
 
-    settings = Utility.serializeCreateOptions(settings, createOptionsVal);
+    settings = Utility.serializeCreateOptions("testModule", settings, createOptionsVal);
     const outStr = JSON.stringify(settings);
     const expected = "{\"image\":\"test\",\"createOptions\":\"{\\\"Env\\\":[\\\"k1=v1\\\",\\\"k2=v2\\\",\\\"k3=v3\\\"]}\"}";
+    assert.equal(outStr, expected);
+  }).timeout(60 * 1000);
+
+  test("serializeCreateOptionsStringWithLinesBreaks", async() => {
+    const createOptionsVal =  "{\r\n  \"ExposedPorts\": {\r\n    \"1680/udp\": {}\r\n  },\r\n  \"HostConfig\": {\r\n    \"PortBindings\": {\r\n      \"1680/udp\": [\r\n        {\r\n          \"HostPort\": \"1680\",\r\n          \"HostIp\":\"172.17.0.1\"\r\n        }\r\n      ]\r\n    }\r\n  }\r\n}\r\n\r\n";
+
+    let settings = {
+      image: "test",
+      createOptions: createOptionsVal,
+    };
+
+    settings = Utility.serializeCreateOptions("testModule", settings, createOptionsVal);
+    const outStr = JSON.stringify(settings);
+    const expected = "{\"image\":\"test\",\"createOptions\":\"{\\\"ExposedPorts\\\":{\\\"1680/udp\\\":{}},\\\"HostConfig\\\":{\\\"PortBindings\\\":{\\\"1680/udp\\\":[{\\\"HostPort\\\":\\\"1680\\\",\\\"HostIp\\\":\\\"172.17.0.1\\\"}]}}}\"}";
     assert.equal(outStr, expected);
   }).timeout(60 * 1000);
 


### PR DESCRIPTION
After the change to limit the createOptions length I could not build and push my IoT Edge solution.

The problem origin was the fact that the createOptions was copied from Azure Portal, containing line breaks and spaces. The extension wrongly assumed that it was longer than 4K.

The createOptions that was failing was:
```
"{\r\n  \"ExposedPorts\": {\r\n    \"1680/udp\": {}\r\n  },\r\n  \"HostConfig\": {\r\n    \"PortBindings\": {\r\n      \"1680/udp\": [\r\n        {\r\n          \"HostPort\": \"1680\",\r\n          \"HostIp\":\"172.17.0.1\"\r\n        }\r\n      ]\r\n    }\r\n  }\r\n}\r\n\r\n"
```


The proposed change will minify the createOptions string using `JSON.stringify(JSON.parse(createOptions), null, 0)`.

Additionally, the error message was improved:
- module where the error happened is displayed
- typo was fixed.

Please let me know if you need more info/changes

Cheers