### PR TITLE
Support deploy to multiple arch

### DIFF
--- a/assets/solution/deployment.template.json
+++ b/assets/solution/deployment.template.json
@@ -1,4 +1,5 @@
 {
+  "$schema-template": "1.0.0",
   "modulesContent": {
     "$edgeAgent": {
       "properties.desired": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,44 @@
 {
   "name": "azure-iot-edge",
-  "version": "1.5.1-rc",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "2.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+          "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+          "dev": true,
+          "requires": {
+            "array-from": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+      "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+      "dev": true
+    },
     "@types/bluebird": {
       "version": "3.5.20",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
@@ -87,6 +122,12 @@
         "@types/bluebird": "*",
         "@types/request": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.5.tgz",
+      "integrity": "sha512-Wnuv66VhvAD2LEJfZkq8jowXGxe+gjVibeLCYcVBp7QLdw0BFx2sRkKzoiiDkYEPGg5VyqO805Rcj0stVjQwCQ==",
+      "dev": true
     },
     "@types/strip-json-comments": {
       "version": "0.0.30",
@@ -228,6 +269,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-slice": {
@@ -908,7 +955,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -1944,6 +1991,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "dev": true
+    },
     "jwa": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
@@ -2046,6 +2099,12 @@
         "lodash._root": "^3.0.0"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -2107,6 +2166,12 @@
         "lodash._reinterpolate": "^3.0.0",
         "lodash.escape": "^3.0.0"
       }
+    },
+    "lolex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -2336,6 +2401,27 @@
         "duplexer2": "0.0.2"
       }
     },
+    "nise": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
+      "integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "3.0.0",
+        "just-extend": "^3.0.0",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
+      }
+    },
     "node.extend": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
@@ -2448,6 +2534,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -2772,6 +2875,40 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
+    "sinon": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+      "integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.2",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.6",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2956,6 +3093,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -3094,6 +3237,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typescript": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,11 @@
         "command": "azure-iot-edge.setModuleCred",
         "title": "Set Module Credentials to User Settings",
         "category": "Azure IoT Edge"
+      },
+      { 
+        "command": "azure-iot-edge.setDefaultPlatform",
+        "title": "Set Default Target Platform for Edge Solution",
+        "category": "Azure IoT Edge"
       }
     ],
     "configuration": {
@@ -194,6 +199,16 @@
           "type": "string",
           "default": "",
           "description": "Edge Module CA path"
+        },
+        "azure-iot-edge.Platforms": {
+          "type": "array",
+          "default": ["amd64", "arm32v7", "windows-amd64"],
+          "description": "Edge Module target platforms"
+        },
+        "azure-iot-edge.DefaultPlatform": {
+          "type": "string",
+          "default": "amd64",
+          "description": "Current default target platform for Edge Module"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -246,13 +246,20 @@
           "description": "Edge Module CA path"
         },
         "azure-iot-edge.Platforms": {
-          "type": "array",
-          "default": ["amd64", "arm32v7", "windows-amd64"],
+          "type": "object",
+          "default": {
+            "amd64": [],
+            "arm32v7": [], 
+            "windows-amd64": []
+          },
           "description": "Edge Module target platforms"
         },
         "azure-iot-edge.DefaultPlatform": {
-          "type": "string",
-          "default": "amd64",
+          "type": "object",
+          "default": {
+            "platform": "amd64",
+            "alias": null
+          },
           "description": "Current default target platform for Edge Module"
         }
       }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,32 @@
           "group": "edge@4"
         },
         {
-          "when": "resourceFilename == deployment.json",
+          "when": "resourceFilename == deployment.amd64.json",
+          "command": "azure-iot-edge.runSolution",
+          "group": "edge@0"
+        },
+        {
+          "when": "resourceFilename == deployment.amd64.debug.json",
+          "command": "azure-iot-edge.runSolution",
+          "group": "edge@0"
+        },
+        {
+          "when": "resourceFilename == deployment.arm32v7.json",
+          "command": "azure-iot-edge.runSolution",
+          "group": "edge@0"
+        },
+        {
+          "when": "resourceFilename == deployment.arm32v7.debug.json",
+          "command": "azure-iot-edge.runSolution",
+          "group": "edge@0"
+        },
+        {
+          "when": "resourceFilename == deployment.windows-amd64.json",
+          "command": "azure-iot-edge.runSolution",
+          "group": "edge@0"
+        },
+        {
+          "when": "resourceFilename == deployment.windows-amd64.debug.json",
           "command": "azure-iot-edge.runSolution",
           "group": "edge@0"
         },

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
         "title": "Set Module Credentials to User Settings",
         "category": "Azure IoT Edge"
       },
-      { 
+      {
         "command": "azure-iot-edge.setDefaultPlatform",
         "title": "Set Default Target Platform for Edge Solution",
         "category": "Azure IoT Edge"
@@ -249,7 +249,7 @@
           "type": "object",
           "default": {
             "amd64": [],
-            "arm32v7": [], 
+            "arm32v7": [],
             "windows-amd64": []
           },
           "description": "Edge Module target platforms"
@@ -413,11 +413,13 @@
     "@types/node": "^6.0.40",
     "@types/request-promise": "^4.1.41",
     "@types/strip-json-comments": "0.0.30",
+    "@types/sinon": "^5.0.5",
     "azure-arm-resource": "^3.1.1-preview",
     "mocha": "^5.1.1",
     "tslint": "^5.7.0",
     "typescript": "^2.0.3",
-    "vscode": "^1.1.17"
+    "vscode": "^1.1.17",
+    "sinon": "^7.1.1"
   },
   "dependencies": {
     "azure-arm-containerregistry": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
           "group": "edge@4"
         },
         {
-          "when": "resourceFilename =~ /deployment(?!\\.template\\.)(\\.([a-z,0-9]+)*)?(\\.debug)?.json/",
+          "when": "resourceFilename =~ /deployment(?!\\.template\\.)(\\.[a-z0-9]+)*(\\.debug)?.json/",
           "command": "azure-iot-edge.runSolution",
           "group": "edge@0"
         },
@@ -201,7 +201,7 @@
           "default": "",
           "description": "Edge Module CA path"
         },
-        "azure-iot-edge.Platforms": {
+        "azure-iot-edge.platforms": {
           "type": "object",
           "default": {
             "amd64": [],
@@ -210,7 +210,7 @@
           },
           "description": "Edge Module target platforms"
         },
-        "azure-iot-edge.DefaultPlatform": {
+        "azure-iot-edge.defaultPlatform": {
           "type": "object",
           "default": {
             "platform": "amd64",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "onCommand:azure-iot-edge.setupIotedgehubdev",
     "onCommand:azure-iot-edge.startEdgeHubSingle",
     "onCommand:azure-iot-edge.setModuleCred",
+    "onCommand:azure-iot-edge.setDefaultPlatform",
     "workspaceContains:**/deployment.template.json"
   ],
   "main": "./out/src/extension",
@@ -72,72 +73,27 @@
           "group": "edge@0"
         },
         {
-          "when": "resourceFilename == deployment.template.json",
+          "when": "resourceFilename =~ /deployment.template(\\.debug)?.json/",
           "command": "azure-iot-edge.buildSolution",
           "group": "edge@1"
         },
         {
-          "when": "resourceFilename == deployment.template.debug.json",
-          "command": "azure-iot-edge.buildSolution",
-          "group": "edge@1"
-        },
-        {
-          "when": "resourceFilename == deployment.template.json",
+          "when": "resourceFilename =~ /deployment.template(\\.debug)?.json/",
           "command": "azure-iot-edge.buildAndPushSolution",
           "group": "edge@2"
         },
         {
-          "when": "resourceFilename == deployment.template.debug.json",
-          "command": "azure-iot-edge.buildAndPushSolution",
-          "group": "edge@2"
-        },
-        {
-          "when": "resourceFilename == deployment.template.json",
+          "when": "resourceFilename =~ /deployment.template(\\.debug)?.json/",
           "command": "azure-iot-edge.buildAndRunSolution",
           "group": "edge@3"
         },
         {
-          "when": "resourceFilename == deployment.template.debug.json",
-          "command": "azure-iot-edge.buildAndRunSolution",
-          "group": "edge@3"
-        },
-        {
-          "when": "resourceFilename == deployment.template.json",
+          "when": "resourceFilename =~ /deployment.template(\\.debug)?.json/",
           "command": "azure-iot-edge.generateDeployment",
           "group": "edge@4"
         },
         {
-          "when": "resourceFilename == deployment.template.debug.json",
-          "command": "azure-iot-edge.generateDeployment",
-          "group": "edge@4"
-        },
-        {
-          "when": "resourceFilename == deployment.amd64.json",
-          "command": "azure-iot-edge.runSolution",
-          "group": "edge@0"
-        },
-        {
-          "when": "resourceFilename == deployment.amd64.debug.json",
-          "command": "azure-iot-edge.runSolution",
-          "group": "edge@0"
-        },
-        {
-          "when": "resourceFilename == deployment.arm32v7.json",
-          "command": "azure-iot-edge.runSolution",
-          "group": "edge@0"
-        },
-        {
-          "when": "resourceFilename == deployment.arm32v7.debug.json",
-          "command": "azure-iot-edge.runSolution",
-          "group": "edge@0"
-        },
-        {
-          "when": "resourceFilename == deployment.windows-amd64.json",
-          "command": "azure-iot-edge.runSolution",
-          "group": "edge@0"
-        },
-        {
-          "when": "resourceFilename == deployment.windows-amd64.debug.json",
+          "when": "resourceFilename =~ /deployment(?!\\.template\\.)(\\.([a-z,0-9]+)*)?(\\.debug)?.json/",
           "command": "azure-iot-edge.runSolution",
           "group": "edge@0"
         },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,17 @@
           "group": "edge@1"
         },
         {
+          "when": "resourceFilename == deployment.template.debug.json",
+          "command": "azure-iot-edge.buildSolution",
+          "group": "edge@1"
+        },
+        {
           "when": "resourceFilename == deployment.template.json",
+          "command": "azure-iot-edge.buildAndPushSolution",
+          "group": "edge@2"
+        },
+        {
+          "when": "resourceFilename == deployment.template.debug.json",
           "command": "azure-iot-edge.buildAndPushSolution",
           "group": "edge@2"
         },
@@ -87,7 +97,17 @@
           "group": "edge@3"
         },
         {
+          "when": "resourceFilename == deployment.template.debug.json",
+          "command": "azure-iot-edge.buildAndRunSolution",
+          "group": "edge@3"
+        },
+        {
           "when": "resourceFilename == deployment.template.json",
+          "command": "azure-iot-edge.generateDeployment",
+          "group": "edge@4"
+        },
+        {
+          "when": "resourceFilename == deployment.template.debug.json",
           "command": "azure-iot-edge.generateDeployment",
           "group": "edge@4"
         },

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -111,6 +111,7 @@ export class Constants {
     public static TwinValueMaxSize = 512;
     public static TwinValueMaxChunks = 8;
     public static SchemaTemplate = "$schema-template";
+    public static platformStatusBarTooltip = "Default platform of IoT Edge Solution";
 }
 
 export enum ContainerState {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,6 +12,7 @@ export class Constants {
     public static moduleConfigFileNamePattern = "**/module.json";
     public static moduleConfigFile = "Module Config file";
     public static deploymentTemplatePattern = "**/deployment.template.json";
+    public static debugDeploymentTemplatePattern = "**/deployment.template.debug.json";
     public static deploymentTemplateDesc = "Deployment Template file";
     public static deploymentFilePattern = "**/deployment.json";
     public static deploymentFileDesc = "Deployment Manifest file";
@@ -111,7 +112,7 @@ export class Constants {
     public static TwinValueMaxSize = 512;
     public static TwinValueMaxChunks = 8;
     public static SchemaTemplate = "$schema-template";
-    public static platformStatusBarTooltip = "Default platform of IoT Edge Solution";
+    public static platformStatusBarTooltip = "Default Platform of IoT Edge Solution";
 }
 
 export enum ContainerState {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -105,6 +105,7 @@ export class Constants {
     public static inputNamePattern = "input1,input2,input3";
     public static moduleSchemaVersion = "$schema-version";
     public static groupId = "groupId";
+    public static defPlatformConfig = "DefaultPlatform";
 }
 
 export enum ContainerState {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -106,7 +106,8 @@ export class Constants {
     public static inputNamePattern = "input1,input2,input3";
     public static moduleSchemaVersion = "$schema-version";
     public static groupId = "groupId";
-    public static defPlatformConfig = "DefaultPlatform";
+    public static defPlatformConfig = "defaultPlatform";
+    public static platformsConfig = "platforms";
     public static platformKey = "platform";
     public static aliasKey = "alias";
     public static TwinValueMaxSize = 512;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -47,6 +47,7 @@ export class Constants {
     public static moduleFolder = "modules";
     public static gitIgnore = ".gitignore";
     public static deploymentTemplate = "deployment.template.json";
+    public static deploymentDebugTemplate = "deployment.template.debug.json";
     public static userCancelled = "Cancelled by user";
     public static edgeDisplayName = "Azure IoT Edge";
     public static solutionName = "Solution Name";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -106,8 +106,11 @@ export class Constants {
     public static moduleSchemaVersion = "$schema-version";
     public static groupId = "groupId";
     public static defPlatformConfig = "DefaultPlatform";
+    public static platformKey = "platform";
+    public static aliasKey = "alias";
     public static TwinValueMaxSize = 512;
     public static TwinValueMaxChunks = 8;
+    public static SchemaTemplate = "$schema-template";
 }
 
 export enum ContainerState {

--- a/src/common/moduleInfo.ts
+++ b/src/common/moduleInfo.ts
@@ -13,6 +13,7 @@ export class ModuleInfo {
         this.repositoryName = repositoryName;
         this.imageName = imageName;
         this.moduleTwin = moduleTwin;
+        // TODO: Change to json object
         this.createOptions = createOptions ? createOptions : "{}";
         this.debugImageName = debugImageName;
         this.debugCreateOptions = debugCreateOptions ? debugCreateOptions : "{}";

--- a/src/common/moduleInfo.ts
+++ b/src/common/moduleInfo.ts
@@ -1,0 +1,20 @@
+export class ModuleInfo {
+    public readonly moduleName: string;
+    public readonly repositoryName: string;
+    public readonly imageName: string;
+    public readonly debugImageName: string;
+    public readonly moduleTwin: object;
+    public readonly createOptions: string;
+    public readonly debugCreateOptions: string;
+
+    constructor(moduleName: string, repositoryName: string, imageName: string, moduleTwin: object, createOptions: string,
+                debugImageName: string, debugCreateOptions: string) {
+        this.moduleName = moduleName;
+        this.repositoryName = repositoryName;
+        this.imageName = imageName;
+        this.moduleTwin = moduleTwin;
+        this.createOptions = createOptions ? createOptions : "{}";
+        this.debugImageName = debugImageName;
+        this.debugCreateOptions = debugCreateOptions ? debugCreateOptions : "{}";
+    }
+}

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -12,9 +12,7 @@ export class Platform {
     }
 
     public static getDefaultPlatformStr(): string {
-        const defaultPlatform = Platform.getDefaultPlatform();
-        const alias = defaultPlatform.alias;
-        return alias ? `${alias}(${defaultPlatform.platform})` : defaultPlatform.platform;
+        return Platform.getDefaultPlatform().getDisplayName();
     }
 
     public static getPlatformsSetting(): Platform[] {
@@ -40,7 +38,7 @@ export class Platform {
     public readonly alias: string;
 
     constructor(platform: string, alias: string) {
-        this.platform = platform;
+        this.platform = platform ? platform : "amd64";
         this.alias = alias;
     }
 

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -16,7 +16,7 @@ export class Platform {
     }
 
     public static getPlatformsSetting(): Platform[] {
-        const platformObjs = Utility.getConfiguration().get<any>("Platforms");
+        const platformObjs = Utility.getConfiguration().get<any>(Constants.platformsConfig);
         const platforms: Platform[]  = [];
         for (const key in platformObjs) {
             if (platformObjs.hasOwnProperty(key)) {

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -1,0 +1,50 @@
+import { Constants } from "./constants";
+import { Utility } from "./utility";
+
+export class Platform {
+    public static getDefaultPlatform(): Platform {
+        const defaultPlatform = Utility.getConfigurationProperty(Constants.defPlatformConfig);
+        if (!defaultPlatform) {
+            return new Platform("amd64", null);
+        }
+        const platform = defaultPlatform.platform ? defaultPlatform.platform : "amd64";
+        return new Platform(platform, defaultPlatform.alias);
+    }
+
+    public static getDefaultPlatformStr(): string {
+        const defaultPlatform = Platform.getDefaultPlatform();
+        const alias = defaultPlatform.alias;
+        return alias ? `${alias}(${defaultPlatform.platform})` : defaultPlatform.platform;
+    }
+
+    public static getPlatformsSetting(): Platform[] {
+        const platformObjs = Utility.getConfiguration().get<any>("Platforms");
+        const platforms: Platform[]  = [];
+        for (const key in platformObjs) {
+            if (platformObjs.hasOwnProperty(key)) {
+                platforms.push(new Platform(key, null));
+                const valArr: string[] = platformObjs[key];
+                if (valArr) {
+                    valArr.map((alias) => {
+                        if (alias !== key) {
+                            platforms.push(new Platform(key, alias));
+                        }
+                    });
+                }
+            }
+        }
+        return platforms;
+    }
+
+    public readonly platform: string;
+    public readonly alias: string;
+
+    constructor(platform: string, alias: string) {
+        this.platform = platform;
+        this.alias = alias;
+    }
+
+    public getDisplayName() {
+        return this.alias ? `${this.alias}(${this.platform})` : this.platform;
+    }
+}

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -43,6 +43,6 @@ export class Platform {
     }
 
     public getDisplayName() {
-        return this.alias ? `${this.alias}(${this.platform})` : this.platform;
+        return this.alias ? `${this.alias} (${this.platform})` : this.platform;
     }
 }

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -35,7 +35,7 @@ export class Utility {
     }
 
     public static getDefaultPlatform(): string {
-        const defaultPlatform = Utility.getConfigurationProperty("DefaultPlatform");
+        const defaultPlatform = Utility.getConfigurationProperty(Constants.defPlatformConfig);
         return defaultPlatform ? defaultPlatform : "amd64";
     }
 
@@ -317,7 +317,7 @@ export class Utility {
                             dockerFilePath, module.image.buildOptions, module.image.contextPath));
                 }
 
-                const defaultPlatform = Utility.getConfigurationProperty("DefaultPlatform");
+                const defaultPlatform = Utility.getDefaultPlatform();
                 if (platform === defaultPlatform) {
                     moduleToImageMap.set(Utility.getModuleKeyNoPlatform(name, false), image);
                 } else if (platform === `${defaultPlatform}.debug`) {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -113,7 +113,7 @@ export class Utility {
         });
     }
 
-    public static async getInputFilePath(inputFileFromContextMenu: vscode.Uri, filePattern: string, fileDescription: string, eventName: string): Promise<string> {
+    public static async getInputFilePath(inputFileFromContextMenu: vscode.Uri, filePattern: string, fileDescription: string, eventName: string, excludeFilePattern?: string | null): Promise<string> {
         if (!Utility.checkWorkspace()) {
             return null;
         }
@@ -123,7 +123,7 @@ export class Utility {
             return inputFileFromContextMenu.fsPath;
         } else {
             TelemetryClient.sendEvent(eventName, { entry: "commandPalette" });
-            const fileList: vscode.Uri[] = await vscode.workspace.findFiles(filePattern);
+            const fileList: vscode.Uri[] = await vscode.workspace.findFiles(filePattern, excludeFilePattern);
             if (!fileList || fileList.length === 0) {
                 vscode.window.showErrorMessage(`No ${fileDescription} can be found under this workspace.`);
                 return null;

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -13,6 +13,7 @@ import { IDeviceItem } from "../typings/IDeviceItem";
 import { BuildSettings } from "./buildSettings";
 import { Constants, ContainerState } from "./constants";
 import { Executor } from "./executor";
+import { Platform } from "./platform";
 import { TelemetryClient } from "./telemetryClient";
 import { UserCancelledError } from "./UserCancelledError";
 
@@ -34,20 +35,15 @@ export class Utility {
         return (os.platform() === "linux" || os.platform() === "darwin") ? `sudo ${command}` : command;
     }
 
-    public static getDefaultPlatform(): string {
-        const defaultPlatform = Utility.getConfigurationProperty(Constants.defPlatformConfig);
-        return defaultPlatform ? defaultPlatform : "amd64";
-    }
-
-    public static getConfigurationProperty(id: string): string {
+    public static getConfigurationProperty(id: string): any {
         return Utility.getConfiguration().get(id);
     }
 
-    public static async setGlobalConfigurationProperty(id: string, value: string): Promise<void> {
+    public static async setGlobalConfigurationProperty(id: string, value: any): Promise<void> {
         await Utility.getConfiguration().update(id, value, true);
     }
 
-    public static async setWorkspaceConfigurationProperty(id: string, value: string): Promise<void> {
+    public static async setWorkspaceConfigurationProperty(id: string, value: any): Promise<void> {
         await Utility.getConfiguration().update(id, value, false);
     }
 
@@ -317,10 +313,10 @@ export class Utility {
                             dockerFilePath, module.image.buildOptions, module.image.contextPath));
                 }
 
-                const defaultPlatform = Utility.getDefaultPlatform();
-                if (platform === defaultPlatform) {
+                const defaultPlatform: Platform = Platform.getDefaultPlatform();
+                if (platform === defaultPlatform.platform) {
                     moduleToImageMap.set(Utility.getModuleKeyNoPlatform(name, false), image);
-                } else if (platform === `${defaultPlatform}.debug`) {
+                } else if (platform === `${defaultPlatform.platform}.debug`) {
                     moduleToImageMap.set(Utility.getModuleKeyNoPlatform(name, true), image);
                 }
             });

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -34,6 +34,11 @@ export class Utility {
         return (os.platform() === "linux" || os.platform() === "darwin") ? `sudo ${command}` : command;
     }
 
+    public static getDefaultPlatform(): string {
+        const defaultPlatform = Utility.getConfigurationProperty("DefaultPlatform");
+        return defaultPlatform ? defaultPlatform : "amd64";
+    }
+
     public static getConfigurationProperty(id: string): string {
         return Utility.getConfiguration().get(id);
     }

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -498,10 +498,10 @@ export class Utility {
         } else {
             optionStr = JSON.stringify(createOptions);
         }
-        const re = new RegExp(`.{1,${Constants.TwinValueMaxSize}}`, "g");
+        const re = new RegExp(`(.|[\r\n]){1,${Constants.TwinValueMaxSize}}`, "g");
         const options = optionStr.match(re);
         if (options.length > Constants.TwinValueMaxChunks) {
-            throw new Error("Size of createOptions too big. The maxium size of createOptions is 4K");
+            throw new Error(`Size of createOptions of ${settings.image} is too big. The maxium size of createOptions is 4K`);
         }
         options.map((value, index) => {
             if (index === 0) {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -42,6 +42,10 @@ export class Utility {
         await Utility.getConfiguration().update(id, value, true);
     }
 
+    public static async setWorkspaceConfigurationProperty(id: string, value: string): Promise<void> {
+        await Utility.getConfiguration().update(id, value, false);
+    }
+
     public static adjustFilePath(filePath: string): string {
         if (os.platform() === "win32") {
             const windowsShell = vscode.workspace.getConfiguration("terminal").get<string>("integrated.shell.windows");
@@ -230,6 +234,10 @@ export class Utility {
         return `MODULES.${name}.${platform}`;
     }
 
+    public static getModuleKeyNoPlatform(name: string, isDebug: boolean): string {
+        return isDebug ? `MODULES.${name}.debug` : `MODULES.${name}`;
+    }
+
     public static getImage(repo: string, version: string, platform: string): string {
         return `${repo}:${version}-${platform}`;
     }
@@ -302,6 +310,13 @@ export class Utility {
                         image,
                         Utility.getBuildSettings(modulePath,
                             dockerFilePath, module.image.buildOptions, module.image.contextPath));
+                }
+
+                const defaultPlatform = Utility.getConfigurationProperty("DefaultPlatform");
+                if (platform === defaultPlatform) {
+                    moduleToImageMap.set(Utility.getModuleKeyNoPlatform(name, false), image);
+                } else if (platform === `${defaultPlatform}.debug`) {
+                    moduleToImageMap.set(Utility.getModuleKeyNoPlatform(name, true), image);
                 }
             });
         }

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -50,8 +50,10 @@ export class ContainerManager {
     }
 
     public async runSolution(deployFileUri?: vscode.Uri, commands: string[] = []): Promise<void> {
+        // const pattern = "**/deployment(_[a-z,0-9]+)*(\.debug)?.json";
+        const pattern = "{**/deployment_*.json,**/deployment.json,**/deployment_*.debug.json}";
         const deployFile: string = await Utility.getInputFilePath(deployFileUri,
-            Constants.deploymentFilePattern,
+            pattern,
             Constants.deploymentFileDesc,
             `${Constants.runSolutionEvent}.selectDeploymentFile`);
         if (!deployFile) {
@@ -84,7 +86,10 @@ export class ContainerManager {
         const slnPath: string = path.dirname(templateFile);
         await Utility.loadEnv(path.join(slnPath, Constants.envFile));
         await Utility.setSlnModulesMap(slnPath, moduleToImageMap, imageToBuildSettings);
-        const deployFile: string = path.join(slnPath, Constants.outputConfig, Constants.deploymentFile);
+        const templateFileName = path.basename(templateFile);
+        const debug = (templateFileName === Constants.deploymentDebugTemplate) ? ".debug" : "";
+        const deploymentFileName = `deployment_${Utility.getDefaultPlatform()}${debug}.json`;
+        const deployFile: string = path.join(slnPath, Constants.outputConfig, deploymentFileName);
         const dpManifest: any = await this.generateDeploymentString(templateFile, deployFile, moduleToImageMap);
 
         if (!build) {

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { BuildSettings } from "../common/buildSettings";
 import { Constants } from "../common/constants";
 import { Executor } from "../common/executor";
+import { Platform } from "../common/platform";
 import { Utility } from "../common/utility";
 
 export class ContainerManager {
@@ -87,11 +88,10 @@ export class ContainerManager {
         const slnPath: string = path.dirname(templateFile);
         await Utility.loadEnv(path.join(slnPath, Constants.envFile));
         await Utility.setSlnModulesMap(slnPath, moduleToImageMap, imageToBuildSettings);
-        const templateFileName = path.basename(templateFile);
-        const debug = (templateFileName === Constants.deploymentDebugTemplate) ? ".debug" : "";
-        const deploymentFileName = `deployment.${Utility.getDefaultPlatform()}${debug}.json`;
-        const deployFile: string = path.join(slnPath, Constants.outputConfig, deploymentFileName);
-        const dpManifest: any = await this.generateDeploymentString(templateFile, deployFile, moduleToImageMap);
+        const configPath: string = path.join(slnPath, Constants.outputConfig);
+        const deployment: any = await this.generateDeploymentString(templateFile, configPath, moduleToImageMap);
+        const dpManifest: any = deployment.manifestObj;
+        const deployFile: string = deployment.manifestFile;
 
         if (!build) {
             return;
@@ -116,20 +116,27 @@ export class ContainerManager {
     }
 
     private async generateDeploymentString(templateFile: string,
-                                           deployFile: string,
+                                           configPath: string,
                                            moduleToImageMap: Map<string, string>): Promise<any> {
-        const configPath = path.dirname(deployFile);
-        await fse.remove(deployFile);
-
         const data: string = await fse.readFile(templateFile, "utf8");
         const moduleExpanded: string = Utility.expandModules(data, moduleToImageMap);
-        const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream"];
+        const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream", Constants.SchemaTemplate];
         const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, ...exceptStr);
         const dpManifest = Utility.convertCreateOptions(Utility.updateSchema(JSON.parse(generatedDeployFile)));
+        const templateSchemaVersion = dpManifest[Constants.SchemaTemplate];
+        delete dpManifest[Constants.SchemaTemplate];
         // generate config file
         await fse.ensureDir(configPath);
+        const templateFileName = path.basename(templateFile);
+        const debug = (templateFileName === Constants.deploymentDebugTemplate) ? ".debug" : "";
+        const deploymentFileName = templateSchemaVersion > "0.0.1" ? `deployment.${Platform.getDefaultPlatform().platform}${debug}.json` : `deployment${debug}.json`;
+        const deployFile = path.join(configPath, deploymentFileName);
+        await fse.remove(deployFile);
         await fse.writeFile(deployFile, JSON.stringify(dpManifest, null, 2), { encoding: "utf8" });
-        return dpManifest;
+        return {
+            manifestObj: dpManifest,
+            manifestFile: deployFile,
+        };
     }
 
     private getBuildMapFromDeployment(manifestObj: any,

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -50,12 +50,13 @@ export class ContainerManager {
     }
 
     public async runSolution(deployFileUri?: vscode.Uri, commands: string[] = []): Promise<void> {
-        // const pattern = "**/deployment(_[a-z,0-9]+)*(\.debug)?.json";
-        const pattern = "{**/deployment_*.json,**/deployment.json,**/deployment_*.debug.json}";
+        const pattern = "{**/deployment.*.json,**/deployment.json,**/deployment.*.debug.json}";
+        const excludePattern = "{**/deployment.template.json,**/deployment.template.debug.json}";
         const deployFile: string = await Utility.getInputFilePath(deployFileUri,
             pattern,
             Constants.deploymentFileDesc,
-            `${Constants.runSolutionEvent}.selectDeploymentFile`);
+            `${Constants.runSolutionEvent}.selectDeploymentFile`,
+            excludePattern);
         if (!deployFile) {
             return;
         }
@@ -88,7 +89,7 @@ export class ContainerManager {
         await Utility.setSlnModulesMap(slnPath, moduleToImageMap, imageToBuildSettings);
         const templateFileName = path.basename(templateFile);
         const debug = (templateFileName === Constants.deploymentDebugTemplate) ? ".debug" : "";
-        const deploymentFileName = `deployment_${Utility.getDefaultPlatform()}${debug}.json`;
+        const deploymentFileName = `deployment.${Utility.getDefaultPlatform()}${debug}.json`;
         const deployFile: string = path.join(slnPath, Constants.outputConfig, deploymentFileName);
         const dpManifest: any = await this.generateDeploymentString(templateFile, deployFile, moduleToImageMap);
 

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -196,6 +196,7 @@ export class EdgeManager {
         const defaultPlatform = await vscode.window.showQuickPick(platformNames, { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
         if (defaultPlatform) {
             await Utility.setWorkspaceConfigurationProperty(Constants.defPlatformConfig, platformMap.get(defaultPlatform));
+            outputChannel.appendLine(`Default platform is ${defaultPlatform} now.`);
         }
     }
 
@@ -322,7 +323,7 @@ export class EdgeManager {
 
         const templateDebugFile = path.join(slnPath, Constants.deploymentDebugTemplate);
         const debugTemplateEnv = {usernameEnv: undefined, passwordEnv: undefined};
-        if (await fse.exists(templateDebugFile)) {
+        if (await fse.pathExists(templateDebugFile)) {
             const templateDebugJson = Utility.updateSchema(await fse.readJson(templateDebugFile));
             const envs = await this.addModuleToDeploymentTemplate(templateDebugJson, templateDebugFile, envFilePath, moduleInfo, needUpdateRegistry, isNewSolution, true);
             debugTemplateEnv.usernameEnv = envs.usernameEnv;

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -180,7 +180,7 @@ export class EdgeManager {
         const platforms: string[] = Utility.getConfiguration().get<string[]>("Platforms");
         const defaultPlatform = await vscode.window.showQuickPick(platforms, { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
         if (defaultPlatform) {
-            await Utility.setWorkspaceConfigurationProperty("DefaultPlatform", defaultPlatform);
+            await Utility.setWorkspaceConfigurationProperty(Constants.defPlatformConfig, defaultPlatform);
         }
     }
 
@@ -188,23 +188,18 @@ export class EdgeManager {
         let debugCreateOptions = "";
         switch (template) {
             case Constants.LANGUAGE_CSHARP:
-                debugCreateOptions = "";
-                // check platform disable debug?
                 break;
             case Constants.CSHARP_FUNCTION:
-                // check platform disable debug?
                 break;
             case Constants.LANGUAGE_NODE:
                 debugCreateOptions = `{"ExposedPorts":{"9229/tcp":{}},"HostConfig":{"PortBindings":{"9229/tcp":[{"HostPort":"9229"}]}}}`;
                 break;
             case Constants.LANGUAGE_C:
-                // check platform disable debug?
                 break;
             case Constants.LANGUAGE_JAVA:
                 debugCreateOptions = `{"HostConfig":{"PortBindings":{"5005/tcp":[{"HostPort":"5005"}]}}}`;
                 break;
             case Constants.LANGUAGE_PYTHON:
-                // check platform disable debug?
                 break;
             default:
                 break;

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -195,11 +195,13 @@ export class EdgeManager {
                 debugCreateOptions = `{"ExposedPorts":{"9229/tcp":{}},"HostConfig":{"PortBindings":{"9229/tcp":[{"HostPort":"9229"}]}}}`;
                 break;
             case Constants.LANGUAGE_C:
+                debugCreateOptions = `{"HostConfig": {"Privileged": true}}"`;
                 break;
             case Constants.LANGUAGE_JAVA:
                 debugCreateOptions = `{"HostConfig":{"PortBindings":{"5005/tcp":[{"HostPort":"5005"}]}}}`;
                 break;
             case Constants.LANGUAGE_PYTHON:
+                debugCreateOptions = `{"ExposedPorts":{"5678/tcp":{}},"HostConfig":{"PortBindings":{"5678/tcp":[{"HostPort":"5678"}]}}}`;
                 break;
             default:
                 break;
@@ -302,7 +304,7 @@ export class EdgeManager {
 
         const templateDebugFile = path.join(slnPath, Constants.deploymentDebugTemplate);
         const debugTemplateEnv = {usernameEnv: undefined, passwordEnv: undefined};
-        if (templateDebugFile) {
+        if (await fse.exists(templateDebugFile)) {
             const templateDebugJson = Utility.updateSchema(await fse.readJson(templateDebugFile));
             const envs = await this.addModuleToDeploymentTemplate(templateDebugJson, templateDebugFile, envFilePath, template, moduleInfo, isNewSolution, true);
             debugTemplateEnv.usernameEnv = envs.usernameEnv;
@@ -340,8 +342,6 @@ export class EdgeManager {
         if (template !== Constants.STREAM_ANALYTICS) {
             result = await this.updateRegistrySettings(address, registries, envFilePath);
         }
-
-        // await this.addModuleProj(targetModulePath, moduleName, repositoryName, template, outputChannel, extraProps);
 
         const imageName = isDebug ? moduleInfo.debugImageName : moduleInfo.imageName;
         const createOptions = isDebug ? moduleInfo.debugCreateOptions : moduleInfo.createOptions;

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -13,6 +13,7 @@ import * as vscode from "vscode";
 import { Constants } from "../common/constants";
 import { Executor } from "../common/executor";
 import { ModuleInfo } from "../common/moduleInfo";
+import { Platform } from "../common/platform";
 import { TelemetryClient } from "../common/telemetryClient";
 import { UserCancelledError } from "../common/UserCancelledError";
 import { Utility } from "../common/utility";
@@ -178,10 +179,23 @@ export class EdgeManager {
     }
 
     public async selectDefaultPlatform(outputChannel: vscode.OutputChannel) {
-        const platforms: string[] = Utility.getConfiguration().get<string[]>("Platforms");
-        const defaultPlatform = await vscode.window.showQuickPick(platforms, { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
+        const platforms: Platform[] = Platform.getPlatformsSetting();
+        const keyWithAlias: string[] = [];
+        const defaultKeys: string[] = [];
+        const platformMap: Map<string, any> = new Map();
+        platforms.forEach((value: Platform) => {
+            const displayName: string = value.getDisplayName();
+            if (!value.alias) {
+                defaultKeys.push(displayName);
+            } else {
+                keyWithAlias.push(displayName);
+            }
+            platformMap.set(displayName, value);
+        });
+        const platformNames: string[] = (keyWithAlias.sort()).concat(defaultKeys.sort());
+        const defaultPlatform = await vscode.window.showQuickPick(platformNames, { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
         if (defaultPlatform) {
-            await Utility.setWorkspaceConfigurationProperty(Constants.defPlatformConfig, defaultPlatform);
+            await Utility.setWorkspaceConfigurationProperty(Constants.defPlatformConfig, platformMap.get(defaultPlatform));
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { Constants } from "./common/constants";
 import { ErrorData } from "./common/ErrorData";
 import { Executor } from "./common/executor";
 import { NSAT } from "./common/nsat";
+import { Platform } from "./common/platform";
 import { TelemetryClient } from "./common/telemetryClient";
 import { UserCancelledError } from "./common/UserCancelledError";
 import { Utility } from "./common/utility";
@@ -28,12 +29,12 @@ export function activate(context: vscode.ExtensionContext) {
 
     const statusBar: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000);
     statusBar.command = "azure-iot-edge.setDefaultPlatform";
-    statusBar.text = formatStatusBarText(Utility.getDefaultPlatform());
+    statusBar.text = formatStatusBarText(Platform.getDefaultPlatformStr());
     statusBar.tooltip = "Default platform of IoT Edge Solution";
     statusBar.show();
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-        statusBar.text = formatStatusBarText(Utility.getDefaultPlatform());
+        statusBar.text = formatStatusBarText(Platform.getDefaultPlatformStr());
     }));
 
     context.subscriptions.push(statusBar);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,11 +30,13 @@ export function activate(context: vscode.ExtensionContext) {
     const statusBar: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000);
     statusBar.command = "azure-iot-edge.setDefaultPlatform";
     statusBar.text = formatStatusBarText(Platform.getDefaultPlatformStr());
-    statusBar.tooltip = "Default platform of IoT Edge Solution";
+    statusBar.tooltip = Constants.platformStatusBarTooltip;
     statusBar.show();
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-        statusBar.text = formatStatusBarText(Platform.getDefaultPlatformStr());
+        if (e.affectsConfiguration("azure-iot-edge.DefaultPlatform")) {
+            statusBar.text = formatStatusBarText(Platform.getDefaultPlatformStr());
+        }
     }));
 
     context.subscriptions.push(statusBar);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
     statusBar.show();
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-        if (e.affectsConfiguration("azure-iot-edge.DefaultPlatform")) {
+        if (e.affectsConfiguration("azure-iot-edge.defaultPlatform")) {
             statusBar.text = formatStatusBarText(Platform.getDefaultPlatformStr());
         }
     }));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerHoverProvider([{ language: "json" }, { language: "jsonc" }], new ConfigHoverProvider()));
     // Calling registerDefinitionProvider will add "Go to definition" and "Peek definition" context menus to documents matched with the filter.
     // Use the strict { pattern: "**/deployment.template.json" } instead of { language: "json" }, { language: "jsonc" } to avoid polluting the context menu of non-config JSON files.
-    context.subscriptions.push(vscode.languages.registerDefinitionProvider([{ pattern: "**/deployment.template.json" }], new ConfigDefinitionProvider()));
+    context.subscriptions.push(vscode.languages.registerDefinitionProvider(
+        [{ pattern: "**/deployment.template.json" }, { pattern: "**/deployment.template.debug.json" }], new ConfigDefinitionProvider()));
 
     const diagCollection: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(Constants.edgeDisplayName);
     const configDiagnosticProvider: ConfigDiagnosticProvider = new ConfigDiagnosticProvider();
@@ -143,8 +144,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     initCommandAsync(context, outputChannel,
         "azure-iot-edge.setDefaultPlatform",
-        (): Promise<void> => {
-            return edgeManager.selectDefaultPlatform(outputChannel);
+        async (): Promise<void> => {
+            await edgeManager.selectDefaultPlatform(outputChannel);
+            return configDiagnosticProvider.updateDiagnostics(vscode.window.activeTextEditor.document, diagCollection);
         });
 
     context.subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,17 +25,15 @@ export function activate(context: vscode.ExtensionContext) {
     const containerManager = new ContainerManager();
 
     Utility.registerDebugTelemetryListener();
-    const statusBar: vscode.StatusBarItem = vscode.window.createStatusBarItem();
+
+    const statusBar: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10000);
     statusBar.command = "azure-iot-edge.setDefaultPlatform";
-    const defaultPlatform = Utility.getConfigurationProperty("DefaultPlatform");
-    statusBar.text = defaultPlatform ? defaultPlatform : "amd64";
+    statusBar.text = formatStatusBarText(Utility.getDefaultPlatform());
+    statusBar.tooltip = "Default platform of IoT Edge Solution";
     statusBar.show();
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-        const selectedPlatform = Utility.getConfigurationProperty("DefaultPlatform");
-        if (selectedPlatform) {
-            statusBar.text = selectedPlatform;
-        }
+        statusBar.text = formatStatusBarText(Utility.getDefaultPlatform());
     }));
 
     context.subscriptions.push(statusBar);
@@ -157,6 +155,10 @@ export function activate(context: vscode.ExtensionContext) {
     if (folders && folders.length > 0) {
         folders.forEach((value) => edgeManager.checkRegistryEnv(value));
     }
+}
+
+function formatStatusBarText(platform?: string): string {
+    return platform ? `$(circuit-board) ${platform}` : `$(circuit-board) amd64`;
 }
 
 function initCommand(context: vscode.ExtensionContext,

--- a/src/intelliSense/configDiagnosticProvider.ts
+++ b/src/intelliSense/configDiagnosticProvider.ts
@@ -12,13 +12,15 @@ import { IntelliSenseUtility } from "./intelliSenseUtility";
 
 export class ConfigDiagnosticProvider {
     public async updateDiagnostics(document: vscode.TextDocument, diagCollection: vscode.DiagnosticCollection) {
-        if (!document && path.basename(document.uri.fsPath) !== Constants.deploymentTemplate && path.basename(document.uri.fsPath) !== Constants.moduleManifest) {
+        if (!document && path.basename(document.uri.fsPath) !== Constants.deploymentTemplate
+            && path.basename(document.uri.fsPath) !== Constants.deploymentDebugTemplate
+            && path.basename(document.uri.fsPath) !== Constants.moduleManifest) {
             return;
         }
 
         diagCollection.delete(document.uri);
         let diags: vscode.Diagnostic[] = [];
-        if (path.basename(document.uri.fsPath) === Constants.deploymentTemplate) {
+        if (path.basename(document.uri.fsPath) === Constants.deploymentTemplate || path.basename(document.uri.fsPath) === Constants.deploymentDebugTemplate) {
             diags = await this.provideDeploymentTemplateDiagnostics(document);
         } else if (path.basename(document.uri.fsPath) === Constants.moduleManifest) {
             diags = await this.provideModuleManifestDiagnostics(document);

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -154,7 +154,7 @@ suite("utility tests", () => {
   test("getPlatformsSetting", () => {
     sinon.stub(Utility, "getConfiguration").callsFake(() => {
       const stubMap = new Map();
-      stubMap.set("Platforms", {
+      stubMap.set(Constants.platformsConfig, {
         arm32v7 : [],
         amd64 : ["t1", "t2"],
         windows: null,

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -148,7 +148,7 @@ suite("utility tests", () => {
     assert.equal("amd64", platform1.getDisplayName());
 
     const platform2 = new Platform("arm32v7", "test");
-    assert.equal("test(arm32v7)", platform2.getDisplayName());
+    assert.equal("test (arm32v7)", platform2.getDisplayName());
   });
 
   test("getPlatformsSetting", () => {

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -1,8 +1,10 @@
 import * as assert from "assert";
 import * as fse from "fs-extra";
 import * as path from "path";
+import * as sinon from "sinon";
 import { BuildSettings } from "../src/common/buildSettings";
 import { Constants } from "../src/common/constants";
+import { Platform } from "../src/common/platform";
 import { Utility } from "../src/common/utility";
 
 suite("utility tests", () => {
@@ -127,14 +129,42 @@ suite("utility tests", () => {
   });
 
   test("setModuleMap", async () => {
+    sinon.stub(Platform, "getDefaultPlatform").callsFake(() => {
+      return new Platform("arm32v7", "camera");
+    });
     const moduleDir = path.resolve(__dirname, "../../testResources/module1");
     const moduleToImageMap: Map<string, string> = new Map();
     const imageToBuildSettings: Map<string, BuildSettings> = new Map();
     await Utility.setModuleMap(moduleDir, moduleToImageMap, imageToBuildSettings);
-    assert.equal(moduleToImageMap.size, 4);
-    assert.equal(imageToBuildSettings.size, 4);
+    assert.equal(moduleToImageMap.size, 7);
+    assert.equal(moduleToImageMap.get("MODULES.module1"), "localhost:5000/samplemodule:0.0.1-arm32v7");
+    assert.equal(moduleToImageMap.get("MODULES.module1.debug"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");
+    assert.equal(imageToBuildSettings.size, 5);
     assert.equal(imageToBuildSettings.get("localhost:5000/samplemodule:0.0.1-amd64").options.length, 8);
   }).timeout(60 * 1000);
+
+  test("getDisplayName", () => {
+    const platform1 = new Platform("amd64", null);
+    assert.equal("amd64", platform1.getDisplayName());
+
+    const platform2 = new Platform("arm32v7", "test");
+    assert.equal("test(arm32v7)", platform2.getDisplayName());
+  });
+
+  test("getPlatformsSetting", () => {
+    sinon.stub(Utility, "getConfiguration").callsFake(() => {
+      const stubMap = new Map();
+      stubMap.set("Platforms", {
+        arm32v7 : [],
+        amd64 : ["t1", "t2"],
+        windows: null,
+        test: ["test"],
+      });
+      return stubMap;
+    });
+    const platforms: Platform[] = Platform.getPlatformsSetting();
+    assert.equal(platforms.length, 6);
+  });
 
   test("replaceAll", async () => {
     // tslint:disable-next-line:quotemark

--- a/testResources/module1/module.json
+++ b/testResources/module1/module.json
@@ -9,6 +9,7 @@
               "amd64": "./Dockerfile", 
               "amd64.debug": "./Dockerfile.amd64.debug",
               "arm32v7": "./Dockerfile.arm32v7",
+              "arm32v7.debug": "./Dockerfile.arm32.debug",
               "windows-amd64": "./Dockerfile"
           }
       },


### PR DESCRIPTION
1. Add user setting to configure the supported platforms (platform/alias).
2. Add user setting to set the default platform.
3. Module ref parameter in deploy.template.json by default will not show platform. And the build time will leverage the default platform the build the image.
4. Add debug template in to the project.  When module added, the default container createoption of debug will be added to debug template. 