### PR TITLE
Default createOptions type is json object

### DIFF
--- a/assets/solution/deployment.template.json
+++ b/assets/solution/deployment.template.json
@@ -17,7 +17,7 @@
             "type": "docker",
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
-              "createOptions": "{}"
+              "createOptions": {}
             }
           },
           "edgeHub": {
@@ -26,7 +26,15 @@
             "restartPolicy": "always",
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
-              "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
+              "createOptions": {
+                "HostConfig": {
+                  "PortBindings": {
+                    "5671/tcp": [{"HostPort": "5671"}],
+                    "8883/tcp": [{"HostPort": "8883"}],
+                    "443/tcp": [{"HostPort": "443"}]
+                  }
+                }
+              }
             }
           }
         },
@@ -38,7 +46,7 @@
             "restartPolicy": "always",
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
-              "createOptions": "{}"
+              "createOptions": {}
             }
           }
         }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -81,8 +81,6 @@ export class Constants {
     public static launchJava = "launch_java.json";
     public static launchPython = "launch_python.json";
     public static noSolutionFileWithModulesFolder = "No solution file for the selected modules folder can be found in workspace.";
-    public static manifestGenerated = "Deployment manifest has been generated at config/deployment.json.";
-    public static manifestGeneratedWithBuild = `${Constants.manifestGenerated} Module images are being built.`;
     public static selectPlatform = "Select Platform";
     // the last item is the module name enterred by the user which cannot be determined yet and will be skipped for checking
     public static moduleDeploymentManifestJsonPath = ["modulesContent", "$edgeAgent", "properties.desired", "modules", "*"];

--- a/src/common/moduleInfo.ts
+++ b/src/common/moduleInfo.ts
@@ -7,15 +7,15 @@ export class ModuleInfo {
     public readonly createOptions: string;
     public readonly debugCreateOptions: string;
 
-    constructor(moduleName: string, repositoryName: string, imageName: string, moduleTwin: object, createOptions: string,
-                debugImageName: string, debugCreateOptions: string) {
+    constructor(moduleName: string, repositoryName: string, imageName: string, moduleTwin: object, createOptions: any,
+                debugImageName: string, debugCreateOptions: any) {
         this.moduleName = moduleName;
         this.repositoryName = repositoryName;
         this.imageName = imageName;
         this.moduleTwin = moduleTwin;
         // TODO: Change to json object
-        this.createOptions = createOptions ? createOptions : "{}";
+        this.createOptions = createOptions ? createOptions : {};
         this.debugImageName = debugImageName;
-        this.debugCreateOptions = debugCreateOptions ? debugCreateOptions : "{}";
+        this.debugCreateOptions = debugCreateOptions ? debugCreateOptions : {};
     }
 }

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -47,8 +47,8 @@ export class ContainerManager {
         if (!templateFile) {
             return;
         }
-        await this.createDeploymentFile(templateFile, true, push, run);
-        vscode.window.showInformationMessage(Constants.manifestGeneratedWithBuild);
+        const deployFile = await this.createDeploymentFile(templateFile, true, push, run);
+        vscode.window.showInformationMessage(`Deployment manifest generated at ${deployFile}. Module images are being built`);
     }
 
     public async runSolution(deployFileUri?: vscode.Uri, commands: string[] = []): Promise<void> {

--- a/src/intelliSense/configCompletionItemProvider.ts
+++ b/src/intelliSense/configCompletionItemProvider.ts
@@ -27,7 +27,7 @@ export class ConfigCompletionItemProvider implements vscode.CompletionItemProvid
                 "\t\"restartPolicy\": \"${4|" + Constants.moduleRestartPolicies.join(",") + "|}\",",
                 "\t\"settings\": {",
                 "\t\t\"image\": \"${5:" + Constants.registryPlaceholder + "}/${6:" + Constants.repoNamePlaceholder + "}:${7:" + Constants.tagPlaceholder + "}\",",
-                "\t\t\"createOptions\": \"${8:{}}\"",
+                "\t\t\"createOptions\": ${8:{}}",
                 "\t}",
                 "}",
             ].join("\n"));

--- a/src/intelliSense/configCompletionItemProvider.ts
+++ b/src/intelliSense/configCompletionItemProvider.ts
@@ -27,7 +27,7 @@ export class ConfigCompletionItemProvider implements vscode.CompletionItemProvid
                 "\t\"restartPolicy\": \"${4|" + Constants.moduleRestartPolicies.join(",") + "|}\",",
                 "\t\"settings\": {",
                 "\t\t\"image\": \"${5:" + Constants.registryPlaceholder + "}/${6:" + Constants.repoNamePlaceholder + "}:${7:" + Constants.tagPlaceholder + "}\",",
-                "\t\t\"createOptions\": ${8:{}}",
+                "\t\t\"createOptions\": {$8}",
                 "\t}",
                 "}",
             ].join("\n"));


### PR DESCRIPTION
1. Make { } as default in deployment.template.json
2. object as default when adding module into deployment.template.json
3. Auto-complete use {} instead of  "{}" as default for createOptions