### PR TITLE
Support build/generate/run customer deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
           "group": "edge@4"
         },
         {
-          "when": "resourceFilename =~ /^deployment(?!.*\\.template\\.json)(\\.[-a-z0-9]+)*(\\.debug)?\\.json$/",
+          "when": "resourceFilename =~ /^deployment(?!.*\\.template\\.json)(\\.debug)?(\\.[-a-z0-9]+)*\\.json$/",
           "command": "azure-iot-edge.runSolution",
           "group": "edge@0"
         },

--- a/package.json
+++ b/package.json
@@ -73,27 +73,27 @@
           "group": "edge@0"
         },
         {
-          "when": "resourceFilename =~ /deployment\\.template(\\.debug)?\\.json/",
+          "when": "resourceFilename =~ /^deployment(\\.debug)?\\.template\\.json$/",
           "command": "azure-iot-edge.buildSolution",
           "group": "edge@1"
         },
         {
-          "when": "resourceFilename =~ /deployment\\.template(\\.debug)?\\.json/",
+          "when": "resourceFilename =~ /^deployment(\\.debug)?\\.template\\.json$/",
           "command": "azure-iot-edge.buildAndPushSolution",
           "group": "edge@2"
         },
         {
-          "when": "resourceFilename =~ /deployment\\.template(\\.debug)?\\.json/",
+          "when": "resourceFilename =~ /^deployment(\\.debug)?\\.template\\.json$/",
           "command": "azure-iot-edge.buildAndRunSolution",
           "group": "edge@3"
         },
         {
-          "when": "resourceFilename =~ /deployment\\.template(\\.debug)?\\.json/",
+          "when": "resourceFilename =~ /^deployment(\\.debug)?\\.template\\.json$/",
           "command": "azure-iot-edge.generateDeployment",
           "group": "edge@4"
         },
         {
-          "when": "resourceFilename =~ /deployment(?!\\.template\\.)(\\.[-a-z0-9]+)*(\\.debug)?\\.json/",
+          "when": "resourceFilename =~ /^deployment(?!.*\\.template\\.json)(\\.[-a-z0-9]+)*(\\.debug)?\\.json$/",
           "command": "azure-iot-edge.runSolution",
           "group": "edge@0"
         },

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,7 +12,9 @@ export class Constants {
     public static moduleConfigFileNamePattern = "**/module.json";
     public static moduleConfigFile = "Module Config file";
     public static deploymentTemplatePattern = "**/deployment.template.json";
-    public static debugDeploymentTemplatePattern = "**/deployment.template.debug.json";
+    public static debugDeploymentTemplatePattern = "**/deployment.debug.template.json";
+    public static tsonPattern = "**/*.template.json";
+    public static tson = ".template.json";
     public static deploymentTemplateDesc = "Deployment Template file";
     public static deploymentFilePattern = "**/deployment.json";
     public static deploymentFileDesc = "Deployment Manifest file";
@@ -48,7 +50,7 @@ export class Constants {
     public static moduleFolder = "modules";
     public static gitIgnore = ".gitignore";
     public static deploymentTemplate = "deployment.template.json";
-    public static deploymentDebugTemplate = "deployment.template.debug.json";
+    public static deploymentDebugTemplate = "deployment.debug.template.json";
     public static userCancelled = "Cancelled by user";
     public static edgeDisplayName = "Azure IoT Edge";
     public static solutionName = "Solution Name";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Calling registerDefinitionProvider will add "Go to definition" and "Peek definition" context menus to documents matched with the filter.
     // Use the strict { pattern: "**/deployment.template.json" } instead of { language: "json" }, { language: "jsonc" } to avoid polluting the context menu of non-config JSON files.
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(
-        [{ pattern: "**/deployment.template.json" }, { pattern: "**/deployment.template.debug.json" }], new ConfigDefinitionProvider()));
+        [{ pattern: Constants.deploymentTemplatePattern }, { pattern: Constants.debugDeploymentTemplatePattern }], new ConfigDefinitionProvider()));
 
     const diagCollection: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(Constants.edgeDisplayName);
     const configDiagnosticProvider: ConfigDiagnosticProvider = new ConfigDiagnosticProvider();


### PR DESCRIPTION
1. Build/Generate deployment now enabled for files with .template.json suffix. The context menu only support for our managed template file. But user could use command palette to choose their customized file.
2. Run now enabled for all .json files under config folder and the deployment.*.json
3. Change the managed debug template name to deployment.debug.template.json