### PR TITLE
Support third party module

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,19 +220,8 @@
         },
         "azure-iot-edge.3rdPartyModuleTemplates": {
           "type": "object",
-          "default": {
-            "version": "1.0.0",
-            "templates": [{
-              "name": "C# TypeEdge Module",
-              "description": "Use TypeEdge C# library to build a module",
-              "command": "dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r ${repositoryName} && echo 222"
-            },{
-              "name": "C# TypeEdge Module 2",
-              "description": "Use TypeEdge C# library to build a module",
-              "command": "echo 222 && dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r ${repositoryName} && echo 222"
-            }]
-          },
-          "description": "3rd party modules"
+          "default": {},
+          "description": "Templates for third party modules"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -225,8 +225,11 @@
             "templates": [{
               "name": "C# TypeEdge Module",
               "description": "Use TypeEdge C# library to build a module",
-              "language": "C#",
               "command": "dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r ${repositoryName} && echo 222"
+            },{
+              "name": "C# TypeEdge Module 2",
+              "description": "Use TypeEdge C# library to build a module",
+              "command": "echo 222 && dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r ${repositoryName} && echo 222"
             }]
           },
           "description": "3rd party modules"

--- a/package.json
+++ b/package.json
@@ -217,6 +217,19 @@
             "alias": null
           },
           "description": "Current default target platform for Edge Module"
+        },
+        "azure-iot-edge.3rdPartyModuleTemplates": {
+          "type": "object",
+          "default": {
+            "version": "1.0.0",
+            "templates": [{
+              "name": "C# TypeEdge Module",
+              "description": "Use TypeEdge C# library to build a module",
+              "language": "C#",
+              "command": "dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r ${repositoryName} && echo 222"
+            }]
+          },
+          "description": "3rd party modules"
         }
       }
     },

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -115,6 +115,8 @@ export class Constants {
     public static TwinValueMaxChunks = 8;
     public static SchemaTemplate = "$schema-template";
     public static platformStatusBarTooltip = "Default Platform of IoT Edge Solution";
+    public static moduleNameSubstitution = "${moduleName}";
+    public static repositoryNameSubstitution = "${repositoryName}";
 }
 
 export enum ContainerState {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -108,6 +108,7 @@ export class Constants {
     public static groupId = "groupId";
     public static defPlatformConfig = "defaultPlatform";
     public static platformsConfig = "platforms";
+    public static thirdPartyModuleTemplatesConfig = "3rdPartyModuleTemplates";
     public static platformKey = "platform";
     public static aliasKey = "alias";
     public static TwinValueMaxSize = 512;

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -452,6 +452,11 @@ export class EdgeManager {
                     "-B");
                 break;
             default:
+                const thirdPartyModuleTemplate = this.get3rdPartyModuleTemplateByName(template);
+                if (thirdPartyModuleTemplate) {
+                    const command = thirdPartyModuleTemplate.command.replace(/\${moduleName}/g, name).replace(/\${repositoryName}/g, repositoryName);
+                    await Executor.executeCMD(outputChannel, command, { cwd: `${parent}`, shell: true }, "");
+                }
                 break;
         }
     }
@@ -721,6 +726,17 @@ export class EdgeManager {
                 description: Constants.EXISTING_MODULE_DESCRIPTION,
             },
         ];
+        const templates = this.get3rdPartyModuleTemplates();
+        if (templates) {
+            templates.forEach((template) => {
+                if (template.name) {
+                    templatePicks.push({
+                        label: template.name,
+                        description: template.description,
+                    });
+                }
+            });
+        }
         if (label === undefined) {
             label = Constants.selectTemplate;
         }
@@ -732,5 +748,15 @@ export class EdgeManager {
             template: templatePick.label,
         });
         return templatePick.label;
+    }
+
+    private get3rdPartyModuleTemplates() {
+        const themplatesConfig = Utility.getConfiguration().get<any>(Constants.thirdPartyModuleTemplatesConfig);
+        return themplatesConfig ? themplatesConfig.templates as any[] : undefined;
+    }
+
+    private get3rdPartyModuleTemplateByName(name: string) {
+        const templates = this.get3rdPartyModuleTemplates();
+        return templates.find((template) => template.name === name);
     }
 }

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -737,7 +737,7 @@ export class EdgeManager {
         const templates = this.get3rdPartyModuleTemplates();
         if (templates) {
             templates.forEach((template) => {
-                if (template.name) {
+                if (template.name && template.command) {
                     templatePicks.push({
                         label: template.name,
                         description: template.description,

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -454,7 +454,9 @@ export class EdgeManager {
             default:
                 const thirdPartyModuleTemplate = this.get3rdPartyModuleTemplateByName(template);
                 if (thirdPartyModuleTemplate) {
-                    const command = thirdPartyModuleTemplate.command.replace(/\${moduleName}/g, name).replace(/\${repositoryName}/g, repositoryName);
+                    const command = thirdPartyModuleTemplate.command
+                        .replace(new RegExp(`\\${Constants.moduleNameSubstitution}`, "g"), name)
+                        .replace(new RegExp(`\\${Constants.repositoryNameSubstitution}`, "g"), repositoryName);
                     await Executor.executeCMD(outputChannel, command, { cwd: `${parent}`, shell: true }, "");
                 }
                 break;
@@ -562,6 +564,7 @@ export class EdgeManager {
         let createOptions: any = {};
         let debugImageName: string = "";
         let debugCreateOptions: any = {};
+        const thirdPartyModuleTemplate = this.get3rdPartyModuleTemplateByName(template);
         if (template === Constants.ACR_MODULE) {
             const acrManager = new AcrManager();
             imageName = await acrManager.selectAcrImage();
@@ -576,6 +579,11 @@ export class EdgeManager {
             imageName = JobInfo.settings.image;
             moduleTwin = JobInfo.twin.content;
             createOptions = JobInfo.settings.createOptions ? JobInfo.settings.createOptions : {};
+        } else if (thirdPartyModuleTemplate) {
+            if (thirdPartyModuleTemplate.command && thirdPartyModuleTemplate.command.includes(Constants.repositoryNameSubstitution)) {
+                repositoryName = await this.inputRepository(module);
+            }
+            imageName = `\${${Utility.getModuleKeyNoPlatform(module, false)}}`;
         } else {
             repositoryName = await this.inputRepository(module);
             imageName = `\${${Utility.getModuleKeyNoPlatform(module, false)}}`;

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -759,12 +759,12 @@ export class EdgeManager {
     }
 
     private get3rdPartyModuleTemplates() {
-        const themplatesConfig = Utility.getConfiguration().get<any>(Constants.thirdPartyModuleTemplatesConfig);
-        return themplatesConfig ? themplatesConfig.templates as any[] : undefined;
+        const templatesConfig = Utility.getConfiguration().get<any>(Constants.thirdPartyModuleTemplatesConfig);
+        return templatesConfig ? templatesConfig.templates as any[] : undefined;
     }
 
     private get3rdPartyModuleTemplateByName(name: string) {
         const templates = this.get3rdPartyModuleTemplates();
-        return templates.find((template) => template.name === name);
+        return templates ? templates.find((template) => template.name === name) : undefined;
     }
 }


### PR DESCRIPTION
Setting sample:
```json
    "azure-iot-edge.3rdPartyModuleTemplates": {
        "version": "1.0.0",
        "templates": [
            {
                "name": "C# TypeEdge Module",
                "description": "Use TypeEdge C# library to build a module",
                "command": "echo 111 && dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r ${repositoryName} && echo ${moduleName}--${repositoryName}"
            },
            {
                "name": "C# TypeEdge Module 2",
                "description": "Use TypeEdge C# library to build a module",
                "command": "echo 222 && dotnet new -i TypeEdge.Module.VsCode && dotnet new typeedgemodulevscode -n ${moduleName} -r hhhh && echo 222-${moduleName}"
            }
        ]
    }
```
`name` and `command` are required, `description` is optional.

![image](https://user-images.githubusercontent.com/1050213/48529259-37fbf900-e8cd-11e8-8171-fa256c4a5934.png)
