### PR TITLE
Support MODULEDIR schema

### DIFF
--- a/assets/solution/deployment.template.json
+++ b/assets/solution/deployment.template.json
@@ -1,5 +1,5 @@
 {
-  "$schema-template": "1.0.0",
+  "$schema-template": "2.0.0",
   "modulesContent": {
     "$edgeAgent": {
       "properties.desired": {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -26,10 +26,14 @@ export class Constants {
     public static groupIDPlaceholder = "%GROUP_ID%";
     public static repositoryPlaceholder = "%REPOSITORY%";
     public static dllPlaceholder = "%DLLNAME%";
-    public static imagePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}|\${PATH(\..+)?(\.debug)?\^.+}/g);
+    public static externalModulePlaceholderPattern: RegExp = new RegExp(/\${MODULEDIR<(.+)>(\..+)?}/g);
+    public static subModulePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}/g);
+    // public static imagePlaceholderPattern: RegExp = new RegExp(
+    //     Constants.subModulePlaceholderPattern + "|" + Constants.externalModulePlaceholderPattern);
+    public static imagePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}|\${MODULEDIR<(.+)>(\..+)?}/g);
     public static versionPlaceholderPattern: RegExp = new RegExp(/\${VERSION\..+}/g);
-    public static externalModulePlaceholderPattern: RegExp = new RegExp(/\${PATH(\..+)?(\.debug)?\^.+}/g);
-    public static replaceExtPlacehoderPattern: RegExp = new RegExp(/\${PATH(\..+)?(\.debug)?\^|{|}/g);
+
+   // public static replaceExtPlacehoderPattern: RegExp = new RegExp(/\${PATH(\..+)?(\.debug)?\^|{|}/g);
     public static assetsFolder = "assets";
     public static solutionFolder = "solution";
     public static LANGUAGE_CSHARP = "C# Module";
@@ -172,6 +176,14 @@ export class Constants {
 
     public static openSampleEvent = "openSample";
     public static openSampleUrlEvent = "openSampleUrl";
+
+    public static subModuleKeyPrefixTemplate(name: string): string {
+        return `MODULES.${name}`;
+    }
+
+    public static extModuleKeyPrefixTemplate(dir: string): string {
+        return `MODULEDIR<${dir}>`;
+    }
 }
 
 export enum ContainerState {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -26,8 +26,10 @@ export class Constants {
     public static groupIDPlaceholder = "%GROUP_ID%";
     public static repositoryPlaceholder = "%REPOSITORY%";
     public static dllPlaceholder = "%DLLNAME%";
-    public static imagePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}/g);
+    public static imagePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}|\${PATH(\..+)?(\.debug)?\^.+}/g);
     public static versionPlaceholderPattern: RegExp = new RegExp(/\${VERSION\..+}/g);
+    public static externalModulePlaceholderPattern: RegExp = new RegExp(/\${PATH(\..+)?(\.debug)?\^.+}/g);
+    public static replaceExtPlacehoderPattern: RegExp = new RegExp(/\${PATH(\..+)?(\.debug)?\^|{|}/g);
     public static assetsFolder = "assets";
     public static solutionFolder = "solution";
     public static LANGUAGE_CSHARP = "C# Module";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -27,9 +27,6 @@ export class Constants {
     public static repositoryPlaceholder = "%REPOSITORY%";
     public static dllPlaceholder = "%DLLNAME%";
     public static externalModulePlaceholderPattern: RegExp = new RegExp(/\${MODULEDIR<(.+)>(\..+)?}/g);
-    public static subModulePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}/g);
-    // public static imagePlaceholderPattern: RegExp = new RegExp(
-    //     Constants.subModulePlaceholderPattern + "|" + Constants.externalModulePlaceholderPattern);
     public static imagePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}|\${MODULEDIR<(.+)>(\..+)?}/g);
     public static versionPlaceholderPattern: RegExp = new RegExp(/\${VERSION\..+}/g);
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -29,8 +29,6 @@ export class Constants {
     public static externalModulePlaceholderPattern: RegExp = new RegExp(/\${MODULEDIR<(.+)>(\..+)?}/g);
     public static imagePlaceholderPattern: RegExp = new RegExp(/\${MODULES\..+}|\${MODULEDIR<(.+)>(\..+)?}/g);
     public static versionPlaceholderPattern: RegExp = new RegExp(/\${VERSION\..+}/g);
-
-   // public static replaceExtPlacehoderPattern: RegExp = new RegExp(/\${PATH(\..+)?(\.debug)?\^|{|}/g);
     public static assetsFolder = "assets";
     public static solutionFolder = "solution";
     public static LANGUAGE_CSHARP = "C# Module";

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -238,10 +238,10 @@ export class Utility {
         }
     }
 
-    public static async setSlnModulesMap(slnPath: string,
-                                         templateFilePath: string,
+    public static async setSlnModulesMap(templateFilePath: string,
                                          moduleToImageMap: Map<string, string>,
                                          imageToBuildSettings?: Map<string, BuildSettings>): Promise<void> {
+        const slnPath: string = path.dirname(templateFilePath);
         const moduleDirs: string[] = await Utility.getSubModules(slnPath);
         await Promise.all(
             moduleDirs.map(async (modulePath) => {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -205,10 +205,6 @@ export class Utility {
         return moduleFolderName.replace(pattern, "_");
     }
 
-    public static getModuleKey(keyPrefix: string, platform: string): string {
-        return `${keyPrefix}.${platform}`;
-    }
-
     public static getDefaultModuleKey(keyPrefix: string, isDebug: boolean) {
         return isDebug ? `${keyPrefix}.debug` : keyPrefix;
     }

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -634,8 +634,8 @@ export class Utility {
         if (!templateFilePath || !await fse.pathExists(templateFilePath)) {
             return modules;
         }
-        const input: string = JSON.stringify(await fse.readJSON(templateFilePath), null, 2);
 
+        const input: string = JSON.stringify(await fse.readJSON(templateFilePath), null, 2);
         const externalModules: string[] = input.match(Constants.externalModulePlaceholderPattern);
 
         if (externalModules) {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -209,16 +209,6 @@ export class Utility {
         return `${keyPrefix}.${platform}`;
     }
 
-    // public static getModuleKeyNoPlatform(keyPrefix: string, platform: string): string|undefined {
-    //     const defaultPlatform: Platform = Platform.getDefaultPlatform();
-    //     if (platform !== defaultPlatform.platform && platform !== `${defaultPlatform.platform}.debug`) {
-    //         return undefined;
-    //     }
-
-    //     const isDebug: boolean = (platform === `${defaultPlatform.platform}.debug`);
-    //     return isDebug ? `${keyPrefix}.debug` : keyPrefix;
-    // }
-
     public static getDefaultModuleKey(keyPrefix: string, isDebug: boolean) {
         return isDebug ? `${keyPrefix}.debug` : keyPrefix;
     }
@@ -286,7 +276,6 @@ export class Utility {
                                      moduleToImageMap: Map<string, string>,
                                      imageToBuildSettings?: Map<string, BuildSettings>): Promise<void> {
         const moduleFile = path.join(moduleFullPath, Constants.moduleManifest);
-        // const name: string = isExternal ? modulePath : path.basename(modulePath);
         if (await fse.pathExists(moduleFile)) {
             const module = await Utility.readJsonAndExpandEnv(moduleFile, Constants.moduleSchemaVersion);
             const platformKeys: string[] = Object.keys(module.image.tag.platforms);

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -176,7 +176,8 @@ export class Utility {
         return JSON.parse(expandedContent);
     }
 
-    public static expandModules(input: string, moduleMap: Map<string, string>): string {
+    public static expandModules(inputJSON: any, moduleMap: Map<string, string>): string {
+        const input = JSON.stringify(inputJSON, null, 2);
         return Utility.expandPlacesHolders(Constants.imagePlaceholderPattern, input, moduleMap);
     }
 
@@ -258,7 +259,7 @@ export class Utility {
                 await Utility.setModuleMap(modulePath, keyPrefix, moduleToImageMap, imageToBuildSettings);
             }),
         );
-        const externalModuleDirs: string[] = await Utility.getExternalModules(slnPath, templateFilePath);
+        const externalModuleDirs: string[] = await Utility.getExternalModules(templateFilePath);
         await Promise.all(
             externalModuleDirs.map(async (module) => {
                 if (module) {
@@ -639,12 +640,13 @@ export class Utility {
         return await Utility.getSubDirectories(modulesPath);
     }
 
-    private static async getExternalModules(slnPath: string, templateFilePath: string): Promise<string[]> {
+    private static async getExternalModules(templateFilePath: string): Promise<string[]> {
         const modules = [];
         if (!templateFilePath || !await fse.pathExists(templateFilePath)) {
             return modules;
         }
-        const input: string = await fse.readFile(templateFilePath, "utf8");
+        const input: string = JSON.stringify(await fse.readJSON(templateFilePath), null, 2);
+
         const externalModules: string[] = input.match(Constants.externalModulePlaceholderPattern);
 
         if (externalModules) {
@@ -660,30 +662,6 @@ export class Utility {
         return modules;
     }
 
-    // private static getImageKeyWithPlatform(moduleKey: string, platform: string, isExternal: boolean = false): string {
-    //     if (isExternal) {
-    //         return `PATH.${platform}^${moduleKey}`;
-    //     } else {
-    //         return Utility.getModuleKey(moduleKey, platform);
-    //     }
-    // }
-
-    // private static getImageKeyWithoutPlatform(moduleKey: string, platform: string, isExternal: boolean = false): string|undefined {
-    //     const defaultPlatform: Platform = Platform.getDefaultPlatform();
-    //     let key;
-    //     if (platform !== defaultPlatform.platform && platform !== `${defaultPlatform.platform}.debug`) {
-    //         return key;
-    //     }
-
-    //     const isDebug: boolean = (platform === `${defaultPlatform.platform}.debug`);
-    //     if (isExternal) {
-    //         key =  isDebug ? `PATH.debug^${moduleKey}` : `PATH^${moduleKey}`;
-    //     } else {
-    //         key =  Utility.getModuleKeyNoPlatform(moduleKey, isDebug);
-    //     }
-
-    //     return key;
-    // }
     private static getModuleKeyFromPlatform(keyPrefix: string, platform: string): string[] {
         const keys: string[] = [`${keyPrefix}.${platform}`];
         const defaultPlatform: Platform = Platform.getDefaultPlatform();

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -631,7 +631,7 @@ export class Utility {
             return modules;
         }
 
-        const input: string = JSON.stringify(await fse.readJSON(templateFilePath), null, 2);
+        const input: string = JSON.stringify(await fse.readJson(templateFilePath), null, 2);
         const externalModules: string[] = input.match(Constants.externalModulePlaceholderPattern);
 
         if (externalModules) {

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -73,7 +73,7 @@ export class ContainerManager {
         const imageToBuildSettings: Map<string, BuildSettings> = new Map();
         const slnPath: string = path.dirname(templateFile);
         await Utility.loadEnv(path.join(slnPath, Constants.envFile));
-        await Utility.setSlnModulesMap(slnPath, templateFile, moduleToImageMap, imageToBuildSettings);
+        await Utility.setSlnModulesMap(templateFile, moduleToImageMap, imageToBuildSettings);
         const configPath: string = path.join(slnPath, Constants.outputConfig);
         const deployment: any = await this.generateDeploymentInfo(templateFile, configPath, moduleToImageMap);
         const dpManifest: any = deployment.manifestObj;

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -72,7 +72,7 @@ export class ContainerManager {
         const imageToBuildSettings: Map<string, BuildSettings> = new Map();
         const slnPath: string = path.dirname(templateFile);
         await Utility.loadEnv(path.join(slnPath, Constants.envFile));
-        await Utility.setSlnModulesMap(slnPath, moduleToImageMap, imageToBuildSettings);
+        await Utility.setSlnModulesMap(slnPath, templateFile, moduleToImageMap, imageToBuildSettings);
         const configPath: string = path.join(slnPath, Constants.outputConfig);
         const deployment: any = await this.generateDeploymentInfo(templateFile, configPath, moduleToImageMap);
         const dpManifest: any = deployment.manifestObj;

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -22,6 +22,7 @@ export class ContainerManager {
         if (moduleConfigFilePath) {
             const directory = path.dirname(moduleConfigFilePath);
             await Utility.loadEnv(path.join(directory, "..", "..", Constants.envFile));
+            await Utility.loadEnv(path.join(directory, Constants.envFile));
             const moduleConfig = await Utility.readJsonAndExpandEnv(moduleConfigFilePath, Constants.moduleSchemaVersion);
             const platforms = moduleConfig.image.tag.platforms;
             const platform = await vscode.window.showQuickPick(Object.keys(platforms), { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
@@ -105,7 +106,7 @@ export class ContainerManager {
     private async generateDeploymentInfo(templateFile: string,
                                          configPath: string,
                                          moduleToImageMap: Map<string, string>): Promise<any> {
-        const data: string = JSON.stringify(await fse.readJSON(templateFile), null, 2);
+        const data: any = await fse.readJSON(templateFile);
         const moduleExpanded: string = Utility.expandModules(data, moduleToImageMap);
         const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream", Constants.SchemaTemplate];
         const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, ...exceptStr);

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -106,7 +106,7 @@ export class ContainerManager {
     private async generateDeploymentInfo(templateFile: string,
                                          configPath: string,
                                          moduleToImageMap: Map<string, string>): Promise<any> {
-        const data: any = await fse.readJSON(templateFile);
+        const data: any = await fse.readJson(templateFile);
         const moduleExpanded: string = Utility.expandModules(data, moduleToImageMap);
         const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream", Constants.SchemaTemplate];
         const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, ...exceptStr);

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -110,10 +110,6 @@ export class ContainerManager {
         const moduleExpanded: string = Utility.expandModules(data, moduleToImageMap);
         const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream", Constants.SchemaTemplate];
         const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, ...exceptStr);
-        moduleToImageMap.forEach((v, k) => {
-            // tslint:disable-next-line:no-console
-            console.info(`key:${k}, value:${v}`);
-        });
         const dpManifest = Utility.convertCreateOptions(Utility.updateSchema(JSON.parse(generatedDeployFile)));
         const templateSchemaVersion = dpManifest[Constants.SchemaTemplate];
         delete dpManifest[Constants.SchemaTemplate];

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -105,10 +105,14 @@ export class ContainerManager {
     private async generateDeploymentInfo(templateFile: string,
                                          configPath: string,
                                          moduleToImageMap: Map<string, string>): Promise<any> {
-        const data: string = await fse.readFile(templateFile, "utf8");
+        const data: string = JSON.stringify(await fse.readJSON(templateFile), null, 2);
         const moduleExpanded: string = Utility.expandModules(data, moduleToImageMap);
         const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream", Constants.SchemaTemplate];
         const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, ...exceptStr);
+        moduleToImageMap.forEach((v, k) => {
+            // tslint:disable-next-line:no-console
+            console.info(`key:${k}, value:${v}`);
+        });
         const dpManifest = Utility.convertCreateOptions(Utility.updateSchema(JSON.parse(generatedDeployFile)));
         const templateSchemaVersion = dpManifest[Constants.SchemaTemplate];
         delete dpManifest[Constants.SchemaTemplate];

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -290,7 +290,7 @@ export class EdgeManager {
             default:
                 break;
         }
-        const debugImageName = `\${${Utility.getModuleKeyNoPlatform(moduleName, true)}}`;
+        const debugImageName = `\${${Utility.getDefaultModuleKey(moduleName, true)}}`;
         return { debugImageName, debugCreateOptions };
     }
 
@@ -582,11 +582,11 @@ export class EdgeManager {
             if (thirdPartyModuleTemplate.command && thirdPartyModuleTemplate.command.includes(Constants.repositoryNameSubstitution)) {
                 repositoryName = await this.inputRepository(module);
             }
-            imageName = `\${${Utility.getModuleKeyNoPlatform(module, false)}}`;
-            debugImageName = `\${${Utility.getModuleKeyNoPlatform(module, true)}}`;
+            imageName = `\${${Utility.getDefaultModuleKey(module, false)}}`;
+            debugImageName = `\${${Utility.getDefaultModuleKey(module, true)}}`;
         } else {
             repositoryName = await this.inputRepository(module);
-            imageName = `\${${Utility.getModuleKeyNoPlatform(module, false)}}`;
+            imageName = `\${${Utility.getDefaultModuleKey(module, false)}}`;
             const debugSettings = await this.generateDebugCreateOptions(module, template);
             debugImageName = debugSettings.debugImageName;
             debugCreateOptions = debugSettings.debugCreateOptions;

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -290,7 +290,7 @@ export class EdgeManager {
             default:
                 break;
         }
-        const debugImageName = `\${${Utility.getDefaultModuleKey(moduleName, true)}}`;
+        const debugImageName = `\${${Utility.getDefaultModuleKey(Constants.subModuleKeyPrefixTemplate(moduleName), true)}}`;
         return { debugImageName, debugCreateOptions };
     }
 
@@ -558,6 +558,7 @@ export class EdgeManager {
         let debugImageName: string = "";
         let debugCreateOptions: any = {};
         let env: object = null;
+        const moduleKeyPrefix = Constants.subModuleKeyPrefixTemplate(module);
         const thirdPartyModuleTemplate = this.get3rdPartyModuleTemplateByName(template);
         if (template === Constants.ACR_MODULE) {
             const acrManager = new AcrManager();
@@ -582,11 +583,11 @@ export class EdgeManager {
             if (thirdPartyModuleTemplate.command && thirdPartyModuleTemplate.command.includes(Constants.repositoryNameSubstitution)) {
                 repositoryName = await this.inputRepository(module);
             }
-            imageName = `\${${Utility.getDefaultModuleKey(module, false)}}`;
-            debugImageName = `\${${Utility.getDefaultModuleKey(module, true)}}`;
+            imageName = `\${${Utility.getDefaultModuleKey(moduleKeyPrefix, false)}}`;
+            debugImageName = `\${${Utility.getDefaultModuleKey(moduleKeyPrefix, true)}}`;
         } else {
             repositoryName = await this.inputRepository(module);
-            imageName = `\${${Utility.getDefaultModuleKey(module, false)}}`;
+            imageName = `\${${Utility.getDefaultModuleKey(moduleKeyPrefix, false)}}`;
             const debugSettings = await this.generateDebugCreateOptions(module, template);
             debugImageName = debugSettings.debugImageName;
             debugCreateOptions = debugSettings.debugCreateOptions;

--- a/src/intelliSense/configCompletionItemProvider.ts
+++ b/src/intelliSense/configCompletionItemProvider.ts
@@ -51,7 +51,7 @@ export class ConfigCompletionItemProvider implements vscode.CompletionItemProvid
 
         if (IntelliSenseUtility.locationMatch(location, Constants.imgDeploymentManifestJsonPath)) {
             const moduleToImageMap: Map<string, string> = new Map();
-            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), document.uri.fsPath, moduleToImageMap);
+            await Utility.setSlnModulesMap(document.uri.fsPath, moduleToImageMap);
             return this.getCompletionItems(Array.from(moduleToImageMap.keys()), document, position, location);
         }
 

--- a/src/intelliSense/configCompletionItemProvider.ts
+++ b/src/intelliSense/configCompletionItemProvider.ts
@@ -51,7 +51,7 @@ export class ConfigCompletionItemProvider implements vscode.CompletionItemProvid
 
         if (IntelliSenseUtility.locationMatch(location, Constants.imgDeploymentManifestJsonPath)) {
             const moduleToImageMap: Map<string, string> = new Map();
-            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap);
+            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), document.uri.fsPath, moduleToImageMap);
             return this.getCompletionItems(Array.from(moduleToImageMap.keys()), document, position, location);
         }
 

--- a/src/intelliSense/configDiagnosticProvider.ts
+++ b/src/intelliSense/configDiagnosticProvider.ts
@@ -36,7 +36,7 @@ export class ConfigDiagnosticProvider {
         const moduleToImageMap: Map<string, string> = new Map();
 
         try {
-            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap);
+            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), document.uri.fsPath, moduleToImageMap);
 
             const rootNode: parser.Node = parser.parseTree(document.getText());
             const moduleJsonPath: string[] = Constants.moduleDeploymentManifestJsonPath.slice(0, - 1); // remove the trailing "*" element

--- a/src/intelliSense/configDiagnosticProvider.ts
+++ b/src/intelliSense/configDiagnosticProvider.ts
@@ -36,7 +36,7 @@ export class ConfigDiagnosticProvider {
         const moduleToImageMap: Map<string, string> = new Map();
 
         try {
-            await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), document.uri.fsPath, moduleToImageMap);
+            await Utility.setSlnModulesMap(document.uri.fsPath, moduleToImageMap);
 
             const rootNode: parser.Node = parser.parseTree(document.getText());
             const moduleJsonPath: string[] = Constants.moduleDeploymentManifestJsonPath.slice(0, - 1); // remove the trailing "*" element

--- a/src/intelliSense/intelliSenseUtility.ts
+++ b/src/intelliSense/intelliSenseUtility.ts
@@ -24,7 +24,7 @@ export class IntelliSenseUtility {
             const imageToBuildSettingsMap: Map<string, BuildSettings> = new Map();
 
             try {
-                await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), document.uri.fsPath, moduleToImageMap, imageToBuildSettingsMap);
+                await Utility.setSlnModulesMap(document.uri.fsPath, moduleToImageMap, imageToBuildSettingsMap);
 
                 const node: parser.Node = location.previousNode;
                 const imagePlaceholder: string = Utility.unwrapImagePlaceholder(node.value);

--- a/src/intelliSense/intelliSenseUtility.ts
+++ b/src/intelliSense/intelliSenseUtility.ts
@@ -24,7 +24,7 @@ export class IntelliSenseUtility {
             const imageToBuildSettingsMap: Map<string, BuildSettings> = new Map();
 
             try {
-                await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), moduleToImageMap, imageToBuildSettingsMap);
+                await Utility.setSlnModulesMap(path.dirname(document.uri.fsPath), document.uri.fsPath, moduleToImageMap, imageToBuildSettingsMap);
 
                 const node: parser.Node = location.previousNode;
                 const imagePlaceholder: string = Utility.unwrapImagePlaceholder(node.value);

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -136,7 +136,7 @@ suite("utility tests", () => {
     const moduleDir = path.resolve(__dirname, "../../testResources/module1");
     const moduleToImageMap: Map<string, string> = new Map();
     const imageToBuildSettings: Map<string, BuildSettings> = new Map();
-    await Utility.setModuleMap(moduleDir, path.basename(moduleDir), moduleToImageMap, imageToBuildSettings);
+    await Utility.setModuleMap(moduleDir, Constants.subModuleKeyPrefixTemplate(path.basename(moduleDir)), moduleToImageMap, imageToBuildSettings);
     assert.equal(moduleToImageMap.size, 7);
     assert.equal(moduleToImageMap.get("MODULES.module1"), "localhost:5000/samplemodule:0.0.1-arm32v7");
     assert.equal(moduleToImageMap.get("MODULES.module1.debug"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");
@@ -155,8 +155,8 @@ suite("utility tests", () => {
     const imageToBuildSettings: Map<string, BuildSettings> = new Map();
     await Utility.setSlnModulesMap(slnDir, templateFile, moduleToImageMap, imageToBuildSettings);
     assert.equal(moduleToImageMap.size, 7);
-    assert.equal(moduleToImageMap.get("PATH^./module1"), "localhost:5000/samplemodule:0.0.1-arm32v7");
-    assert.equal(moduleToImageMap.get("PATH.debug^./module1"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");
+    assert.equal(moduleToImageMap.get("MODULEDIR<./module1>"), "localhost:5000/samplemodule:0.0.1-arm32v7");
+    assert.equal(moduleToImageMap.get("MODULEDIR<./module1>.debug"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");
     assert.equal(imageToBuildSettings.size, 5);
     assert.equal(imageToBuildSettings.get("localhost:5000/samplemodule:0.0.1-amd64").options.length, 8);
     sinon.restore();

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -136,12 +136,30 @@ suite("utility tests", () => {
     const moduleDir = path.resolve(__dirname, "../../testResources/module1");
     const moduleToImageMap: Map<string, string> = new Map();
     const imageToBuildSettings: Map<string, BuildSettings> = new Map();
-    await Utility.setModuleMap(moduleDir, moduleToImageMap, imageToBuildSettings);
+    await Utility.setModuleMap(moduleDir, path.basename(moduleDir), moduleToImageMap, imageToBuildSettings);
     assert.equal(moduleToImageMap.size, 7);
     assert.equal(moduleToImageMap.get("MODULES.module1"), "localhost:5000/samplemodule:0.0.1-arm32v7");
     assert.equal(moduleToImageMap.get("MODULES.module1.debug"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");
     assert.equal(imageToBuildSettings.size, 5);
     assert.equal(imageToBuildSettings.get("localhost:5000/samplemodule:0.0.1-amd64").options.length, 8);
+    sinon.restore();
+  }).timeout(60 * 1000);
+
+  test("setSlnModulesMap", async () => {
+    sinon.stub(Platform, "getDefaultPlatform").callsFake(() => {
+      return new Platform("arm32v7", "camera");
+    });
+    const slnDir = path.resolve(__dirname, "../../testResources");
+    const templateFile = path.join(slnDir, "deployment.template.json");
+    const moduleToImageMap: Map<string, string> = new Map();
+    const imageToBuildSettings: Map<string, BuildSettings> = new Map();
+    await Utility.setSlnModulesMap(slnDir, templateFile, moduleToImageMap, imageToBuildSettings);
+    assert.equal(moduleToImageMap.size, 7);
+    assert.equal(moduleToImageMap.get("PATH^./module1"), "localhost:5000/samplemodule:0.0.1-arm32v7");
+    assert.equal(moduleToImageMap.get("PATH.debug^./module1"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");
+    assert.equal(imageToBuildSettings.size, 5);
+    assert.equal(imageToBuildSettings.get("localhost:5000/samplemodule:0.0.1-amd64").options.length, 8);
+    sinon.restore();
   }).timeout(60 * 1000);
 
   test("getDisplayName", () => {

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -25,7 +25,7 @@ suite("utility tests", () => {
   }).timeout(60 * 1000);
 
   test("expandModules", async () => {
-    const input: string = await fse.readFile(path.resolve(__dirname, "../../testResources/deployment.template.json"), "utf8");
+    const input = await fse.readJSON(path.resolve(__dirname, "../../testResources/deployment.template.json"));
     const mapObj: Map<string, string> = new Map<string, string>();
     mapObj.set("MODULES.SampleModule.amd64", "test.az.io/filter:0.0.1-amd64");
     const generated: string = Utility.expandModules(input, mapObj);

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -153,7 +153,7 @@ suite("utility tests", () => {
     const templateFile = path.join(slnDir, "deployment.template.json");
     const moduleToImageMap: Map<string, string> = new Map();
     const imageToBuildSettings: Map<string, BuildSettings> = new Map();
-    await Utility.setSlnModulesMap(slnDir, templateFile, moduleToImageMap, imageToBuildSettings);
+    await Utility.setSlnModulesMap(templateFile, moduleToImageMap, imageToBuildSettings);
     assert.equal(moduleToImageMap.size, 7);
     assert.equal(moduleToImageMap.get("MODULEDIR<./module1>"), "localhost:5000/samplemodule:0.0.1-arm32v7");
     assert.equal(moduleToImageMap.get("MODULEDIR<./module1>.debug"), "localhost:5000/samplemodule:0.0.1-arm32v7.debug");

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -25,7 +25,7 @@ suite("utility tests", () => {
   }).timeout(60 * 1000);
 
   test("expandModules", async () => {
-    const input = await fse.readJSON(path.resolve(__dirname, "../../testResources/deployment.template.json"));
+    const input = await fse.readJson(path.resolve(__dirname, "../../testResources/deployment.template.json"));
     const mapObj: Map<string, string> = new Map<string, string>();
     mapObj.set("MODULES.SampleModule.amd64", "test.az.io/filter:0.0.1-amd64");
     const generated: string = Utility.expandModules(input, mapObj);

--- a/testResources/deployment.template.json
+++ b/testResources/deployment.template.json
@@ -119,6 +119,16 @@
               "image": "${MODULES.SampleModule.amd64}",
               "createOptions": "{}"
             }
+          },
+          "externalmodule": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "${PATH.debug^./module1}",
+              "createOptions": {}
+            }
           }
         }
       }

--- a/testResources/deployment.template.json
+++ b/testResources/deployment.template.json
@@ -126,7 +126,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "${PATH.debug^./module1}",
+              "image": "${MODULEDIR<./module1>.debug}",
               "createOptions": {}
             }
           }


### PR DESCRIPTION
1. Upgrade the version of new create deployment template to 2.0.0
2. Parse MODULEDIR<> schema to get the external module.json
3. Clean the logic to support submodule/external module