### PR TITLE
isssue #447

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-edge",
   "displayName": "Azure IoT Edge",
   "description": "Develop, deploy, debug, and manage your IoT Edge solution",
-  "version": "1.13.0-rc2",
+  "version": "1.13.0-rc3",
   "publisher": "vsciot-vscode",
   "aiKey": "95b20d64-f54f-4de3-8ad5-165a75a6c6fe",
   "icon": "logo.png",

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -294,8 +294,9 @@ export class Utility {
         }
     }
 
-    // Remove the wrapping "${" and "}" of a image placeholder
+    // Escape JSON string and remove the wrapping "${" and "}" of a image placeholder
     public static unwrapImagePlaceholder(imagePlaceholder: string): string {
+        imagePlaceholder = JSON.stringify(imagePlaceholder).slice(1, -1);
         if (imagePlaceholder.search(Constants.imagePlaceholderPattern) === 0 && imagePlaceholder.endsWith("}")) {
             return imagePlaceholder.slice(2, -1);
         }


### PR DESCRIPTION
The root cause of the issue is, when getting the module, in the map, the key is unescaped string value. However, the parser of intellisense parse the string as JSON value, so to get the key in the map, we should not escape the string.