### PR TITLE
issue #448

### DIFF
--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -22,8 +22,8 @@ export class ContainerManager {
         if (moduleConfigFilePath) {
             const directory = path.dirname(moduleConfigFilePath);
             await Utility.loadEnv(path.join(directory, "..", "..", Constants.envFile));
-            await Utility.loadEnv(path.join(directory, Constants.envFile));
-            const moduleConfig = await Utility.readJsonAndExpandEnv(moduleConfigFilePath, Constants.moduleSchemaVersion);
+            const overrideEnvs = await Utility.parseEnv(path.join(directory, Constants.envFile));
+            const moduleConfig = await Utility.readJsonAndExpandEnv(moduleConfigFilePath, overrideEnvs, Constants.moduleSchemaVersion);
             const platforms = moduleConfig.image.tag.platforms;
             const platform = await vscode.window.showQuickPick(Object.keys(platforms), { placeHolder: Constants.selectPlatform, ignoreFocusOut: true });
             if (platform) {
@@ -109,7 +109,7 @@ export class ContainerManager {
         const data: any = await fse.readJson(templateFile);
         const moduleExpanded: string = Utility.expandModules(data, moduleToImageMap);
         const exceptStr = ["$edgeHub", "$edgeAgent", "$upstream", Constants.SchemaTemplate];
-        const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, ...exceptStr);
+        const generatedDeployFile: string = Utility.expandEnv(moduleExpanded, {}, ...exceptStr);
         const dpManifest = Utility.convertCreateOptions(Utility.updateSchema(JSON.parse(generatedDeployFile)));
         const templateSchemaVersion = dpManifest[Constants.SchemaTemplate];
         delete dpManifest[Constants.SchemaTemplate];

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -17,7 +17,7 @@ suite("utility tests", () => {
     process.env.IMAGE = imageString;
     process.env.edgeAgent = "test";
     const exceptStr: string[] = ["$edgeHub", "$edgeAgent", "$upstream"];
-    const generated: string = Utility.expandEnv(input, ...exceptStr);
+    const generated: string = Utility.expandEnv(input, {}, ...exceptStr);
     const generatedObj = JSON.parse(generated);
     assert.equal(generatedObj.modulesContent
       .$edgeAgent["properties.desired"]


### PR DESCRIPTION
allow .env file under module override the environment from deployment.
Since there may be several modules with .env file, the strategy here is not load the variables into environment. Instead, it just use the variable when expanding the env.