### PR TITLE
Update VS Code warning message while setting module creds

### DIFF
--- a/package.json
+++ b/package.json
@@ -549,7 +549,6 @@
     "azure-arm-containerregistry": "^2.2.0",
     "azure-arm-machinelearningservices": "^1.0.0-preview",
     "azure-arm-streamanalytics": "^1.0.0-preview",
-    "bl": "^2.2.1",
     "body-parser": "^1.18.2",
     "dotenv": "^5.0.1",
     "download-git-repo": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -549,6 +549,7 @@
     "azure-arm-containerregistry": "^2.2.0",
     "azure-arm-machinelearningservices": "^1.0.0-preview",
     "azure-arm-streamanalytics": "^1.0.0-preview",
+    "bl": "^2.2.1",
     "body-parser": "^1.18.2",
     "dotenv": "^5.0.1",
     "download-git-repo": "^1.0.2",

--- a/src/edge/simulator.ts
+++ b/src/edge/simulator.ts
@@ -163,6 +163,7 @@ export class Simulator {
 
     public async setModuleCred(outputChannel: vscode.OutputChannel): Promise<void> {
         return await this.callWithInstallationCheck(outputChannel, async () => {
+            await this.checkIoTedgehubdevConnectionString(outputChannel);
             let storagePath = this.context.storagePath;
             if (!storagePath) {
                 storagePath = path.resolve(os.tmpdir(), "vscodeedge");


### PR DESCRIPTION
The warning message when the edgehubdev config is missing is now the same between azure-iot-edge.setModuleCred and azure-iot-edge.buildAndRunSolution scenarios. This warning allows for the user to regenerate the edgehubdev config.