### PR TITLE
Allow user to select between Edge Runtime 1.0 or 1.1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,6 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                //"--extensionDevelopmentPath=C:\\Work\\AzureIoT\\IoTEdge\\IoTEdgeHubDev\\Modules\\EdgeSolutionTest01"
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ],
             "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                //"--extensionDevelopmentPath=C:\\Work\\AzureIoT\\IoTEdge\\IoTEdgeHubDev\\Modules\\EdgeSolutionTest01"
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ],
             "outFiles": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## 1.24.0 - 2021-3-26
+### Changed
+* Allow user to select Edge Runtime version between 1.0 and 1.1
 
 ## 1.23.0 - 2020-9-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can also trigger following frequently-used commands in context menu.
 - [Develop and deploy a Python module](https://docs.microsoft.com/azure/iot-edge/tutorial-python-module)
 - [Develop and deploy a Node.js module](https://docs.microsoft.com/azure/iot-edge/tutorial-node-module)
 - [Develop and deploy a C module](https://docs.microsoft.com/azure/iot-edge/tutorial-c-module)
-- [Register a new Azure IoT Edge device](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-register-device-vscode)
+- [Register a new Azure IoT Edge device](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-register-device)
 - [Deploy Azure IoT Edge modules](https://docs.microsoft.com/azure/iot-edge/how-to-deploy-modules-vscode)
 - [Debug C# module](https://docs.microsoft.com/azure/iot-edge/how-to-develop-csharp-module)
 - [Debug Node.js module](https://docs.microsoft.com/azure/iot-edge/how-to-develop-node-module)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-edge",
-  "version": "1.23.0",
+  "version": "1.24.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1883,18 +1883,32 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
       }
     },
     "emitter-listener": {
@@ -2971,9 +2985,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "interpret": {
       "version": "1.2.0",
@@ -6366,9 +6380,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xpath.js": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-edge",
   "displayName": "Azure IoT Edge",
   "description": "This extension is now a part of Azure IoT Tools extension pack. We highly recommend installing Azure IoT Tools to get full capabilities for Azure IoT development. Develop, deploy, debug, and manage your IoT Edge solution.",
-  "version": "1.23.0",
+  "version": "1.24.0-rc1",
   "publisher": "vsciot-vscode",
   "aiKey": "95b20d64-f54f-4de3-8ad5-165a75a6c6fe",
   "icon": "logo.png",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "onCommand:azure-iot-edge.addModule",
     "onCommand:azure-iot-edge.stopSolution",
     "onCommand:azure-iot-edge.setupIotedgehubdev",
+    "onCommand:azure-iot-edge.setDefaultEdgeRuntimeVersion",
     "onCommand:azure-iot-edge.startEdgeHubSingle",
     "onCommand:azure-iot-edge.setModuleCred",
     "onCommand:azure-iot-edge.setDefaultPlatform",
@@ -167,6 +168,11 @@
         "category": "Azure IoT Edge"
       },
       {
+        "command": "azure-iot-edge.setDefaultEdgeRuntimeVersion",
+        "title": "Set Default IoT Edge Runtime Version",
+        "category": "Azure IoT Edge"
+      },
+      {
         "command": "azure-iot-edge.startEdgeHubSingle",
         "title": "Start IoT Edge Hub Simulator for Single Module",
         "category": "Azure IoT Edge"
@@ -191,16 +197,6 @@
       "type": "object",
       "title": "Azure IoT Edge configuration",
       "properties": {
-        "azure-iot-edge.version.edgeHub": {
-          "type": "string",
-          "default": "1.0",
-          "description": "Set the edgeHub image version, which will be referenced in deployment manifest."
-        },
-        "azure-iot-edge.version.edgeAgent": {
-          "type": "string",
-          "default": "1.0",
-          "description": "Set the edgeAgent image version, which will be referenced in deployment manifest."
-        },
         "azure-iot-edge.version.tempSensor": {
           "type": "string",
           "default": "1.0",
@@ -283,6 +279,19 @@
             "alias": null
           },
           "description": "Current default target platform for Edge Module"
+        },
+        "azure-iot-edge.version.supported.edgeRuntime": {
+          "type": "array",
+          "default": [
+            "1.0",
+            "1.1"
+          ],
+          "description": "List of supported Edge Runtime images versions"
+        },
+        "azure-iot-edge.version.default.edgeRuntime": {
+          "type": "string",
+          "default": "1.0",
+          "description": "Set the edgeAgent and edgeHub images version, which will be referenced in deployment manifest."
         },
         "azure-iot-edge.3rdPartyModuleTemplates": {
           "type": "object",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -89,6 +89,7 @@ export class Constants {
     public static moduleName = "Module Name";
     public static moduleNamePrompt = "Provide a Module Name";
     public static moduleNameDft = "SampleModule";
+    public static edgeRuntimeVersionPrompt = "Select Azure IoT Edge Runtime (Edge Hub and Edge Agent images) version";    
     public static registryPlaceholder = "<registry>";
     public static repoNamePlaceholder = "<repo-name>";
     public static tagPlaceholder = "<tag>";
@@ -108,6 +109,7 @@ export class Constants {
     public static runSolutionEvent = "runSolution";
     public static generateDeploymentEvent = "generateDeployment";
     public static addModuleEvent = "addModule";
+    public static selectEdgeRuntimeVerEvent = "selectEdgeVer"
     public static launchCSharp = "launch_csharp.json";
     public static launchNode = "launch_node.json";
     public static launchC = "launch_c.json";
@@ -159,6 +161,8 @@ export class Constants {
 
     public static versionEdgeAgent = "version.edgeAgent";
     public static versionEdgeHub = "version.edgeHub";
+    public static versionEdgeRuntime = "version.supported.edgeRuntime";
+    public static versionDefaultEdgeRuntime = "version.default.edgeRuntime";
     public static versionTempSensor = "version.tempSensor";
     public static versionCModule = "version.cmodule";
     public static versionPythonModule = "version.pythonmodule";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -14,7 +14,7 @@ export class Constants {
     public static deploymentTemplatePattern = "**/deployment.template.json";
     public static debugDeploymentTemplatePattern = "**/deployment.debug.template.json";
     public static tsonPattern = "**/*.template.json";
-    public static deploymentTsonPattern = "**/deployment.*.template.json,**/deployment.template.json";
+    public static deploymentJsonPattern = "**/deployment.*.template.json,**/deployment.template.json";
     public static tson = ".template.json";
     public static deploymentTemplateDesc = "Deployment Template file";
     public static deploymentFilePattern = "**/deployment.json";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -89,7 +89,7 @@ export class Constants {
     public static moduleName = "Module Name";
     public static moduleNamePrompt = "Provide a Module Name";
     public static moduleNameDft = "SampleModule";
-    public static edgeRuntimeVersionPrompt = "Select Azure IoT Edge Runtime (Edge Hub and Edge Agent images) version";    
+    public static edgeRuntimeVersionPrompt = "Select Azure IoT Edge Runtime (Edge Hub and Edge Agent images) version";
     public static registryPlaceholder = "<registry>";
     public static repoNamePlaceholder = "<repo-name>";
     public static tagPlaceholder = "<tag>";
@@ -109,7 +109,7 @@ export class Constants {
     public static runSolutionEvent = "runSolution";
     public static generateDeploymentEvent = "generateDeployment";
     public static addModuleEvent = "addModule";
-    public static selectEdgeRuntimeVerEvent = "selectEdgeVer"
+    public static selectEdgeRuntimeVerEvent = "selectEdgeVer";
     public static launchCSharp = "launch_csharp.json";
     public static launchNode = "launch_node.json";
     public static launchC = "launch_c.json";

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -9,6 +9,10 @@ export class Versions {
         return verMap;
     }
 
+    public static getSupportedEdgeRuntimeVersions(): string[] {
+        return Versions.getValue(Constants.versionEdgeRuntime, []) as string[];
+    }
+
     public static installCSharpTemplate(): boolean {
         return Versions.getValue(Constants.installCSharpModule, true) as boolean;
     }
@@ -49,15 +53,50 @@ export class Versions {
         return Versions.getValue(Constants.versionTempSensor, "1.0") as string;
     }
 
+    public static updateEdgeAgentImageVersion(templateJson: any, versionMap: Map<string, string>) {        
+        if(templateJson) {
+            const edgeAgentImage = 
+                templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeAgent"].settings["image"];
+            templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeAgent"].settings["image"] =
+                Versions.getNewImageVersionJson(edgeAgentImage, versionMap);
+        }
+    }
+
+    public static updateEdgeHubImageVersion(templateJson: any, versionMap: Map<string, string>) {        
+        if(templateJson) {
+            const edgeHubImage = templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeHub"].settings["image"];
+            templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeHub"].settings["image"] =
+                Versions.getNewImageVersionJson(edgeHubImage, versionMap);
+        }
+    }
+
     private static edgeAgentVersion(): string {
-        return Versions.getValue(Constants.versionEdgeAgent) as string;
+        return Versions.getDefaultEdgeRuntimeVersion();
     }
 
-    private static edgeHubVersion(): string {
-        return Versions.getValue(Constants.versionEdgeHub, "1.0") as string;
+    public static edgeHubVersion(): string {
+        return Versions.getDefaultEdgeRuntimeVersion();
     }
 
-    private static getValue(key: string, defaultVal: string|boolean = null): string | boolean {
+    private static getDefaultEdgeRuntimeVersion(): string {
+        return Versions.getValue(Constants.versionDefaultEdgeRuntime, "1.0") as string;
+    }
+
+    private static getNewImageVersionJson(input: string, versionMap: Map<string, string>): string {        
+        if (input) {
+            const imageName: string = input.split(":")[0];
+            switch (imageName) {
+                case "mcr.microsoft.com/azureiotedge-agent":
+                    return imageName + ":" + versionMap.get(Constants.edgeAgentVerPlaceHolder);
+                case "mcr.microsoft.com/azureiotedge-hub":
+                    return imageName + ":" + versionMap.get(Constants.edgeHubVerPlaceHolder);
+                default:
+                    return input;
+            }
+        }
+    }
+
+    private static getValue(key: string, defaultVal: string|string[]|boolean = null): string | string[] | boolean {
         const value = Configuration.getConfigurationProperty(key);
         if (value === undefined || value === null) {
             return defaultVal;

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -53,28 +53,20 @@ export class Versions {
         return Versions.getValue(Constants.versionTempSensor, "1.0") as string;
     }
 
-    public static updateEdgeAgentImageVersion(templateJson: any, versionMap: Map<string, string>) {        
-        if(templateJson) {
-            const edgeAgentImage = 
-                templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeAgent"].settings["image"];
-            templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeAgent"].settings["image"] =
-                Versions.getNewImageVersionJson(edgeAgentImage, versionMap);
+    public static updateSystemModuleImageVersion(templateJson: any, moduleName: string, versionMap: Map<string, string>) {
+        if (templateJson) {
+            const sysModuleImage =
+                templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules[moduleName].settings.image;
+            templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules[moduleName].settings.image =
+                Versions.getNewImageVersionJson(sysModuleImage, versionMap);
         }
-    }
-
-    public static updateEdgeHubImageVersion(templateJson: any, versionMap: Map<string, string>) {        
-        if(templateJson) {
-            const edgeHubImage = templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeHub"].settings["image"];
-            templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules["edgeHub"].settings["image"] =
-                Versions.getNewImageVersionJson(edgeHubImage, versionMap);
-        }
-    }
-
-    private static edgeAgentVersion(): string {
-        return Versions.getDefaultEdgeRuntimeVersion();
     }
 
     public static edgeHubVersion(): string {
+        return Versions.getDefaultEdgeRuntimeVersion();
+    }
+
+    private static edgeAgentVersion(): string {
         return Versions.getDefaultEdgeRuntimeVersion();
     }
 
@@ -82,7 +74,7 @@ export class Versions {
         return Versions.getValue(Constants.versionDefaultEdgeRuntime, "1.0") as string;
     }
 
-    private static getNewImageVersionJson(input: string, versionMap: Map<string, string>): string {        
+    private static getNewImageVersionJson(input: string, versionMap: Map<string, string>): string {
         if (input) {
             const imageName: string = input.split(":")[0];
             switch (imageName) {

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,6 +1,8 @@
 import { Configuration } from "./configuration";
 import { Constants } from "./constants";
 
+type ImageJson = "${string}:${string}";
+
 export class Versions {
     public static getRunTimeVersionMap(): Map<string, string> {
         const verMap: Map<string, string> = new Map();
@@ -54,7 +56,7 @@ export class Versions {
     }
 
     public static updateSystemModuleImageVersion(templateJson: any, moduleName: string, versionMap: Map<string, string>) {
-        if (templateJson) {
+        if (templateJson !== undefined) {
             const sysModuleImage =
                 templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules[moduleName].settings.image;
             templateJson.modulesContent.$edgeAgent["properties.desired"].systemModules[moduleName].settings.image =
@@ -74,8 +76,8 @@ export class Versions {
         return Versions.getValue(Constants.versionDefaultEdgeRuntime, "1.0") as string;
     }
 
-    private static getNewImageVersionJson(input: string, versionMap: Map<string, string>): string {
-        if (input) {
+    private static getNewImageVersionJson(input: ImageJson, versionMap: Map<string, string>): string {
+        if (input !== undefined) {
             const imageName: string = input.split(":")[0];
             switch (imageName) {
                 case "mcr.microsoft.com/azureiotedge-agent":

--- a/src/container/containerManager.ts
+++ b/src/container/containerManager.ts
@@ -43,7 +43,7 @@ export class ContainerManager {
     }
 
     public async buildSolution(outputChannel: vscode.OutputChannel, templateUri?: vscode.Uri, push: boolean = true, run: boolean = false): Promise<void> {
-        const pattern = `{${Constants.deploymentTsonPattern}}`;
+        const pattern = `{${Constants.deploymentJsonPattern}}`;
         const templateFile: string = await Utility.getInputFilePath(templateUri,
             pattern,
             Constants.deploymentTemplateDesc,
@@ -56,7 +56,7 @@ export class ContainerManager {
     }
 
     public async generateDeployment(outputChannel: vscode.OutputChannel, templateUri?: vscode.Uri): Promise<void> {
-        const pattern = `{${Constants.deploymentTsonPattern}}`;
+        const pattern = `{${Constants.deploymentJsonPattern}}`;
         const templateFile: string = await Utility.getInputFilePath(templateUri,
             pattern,
             Constants.deploymentTemplateDesc,

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -172,7 +172,7 @@ export class EdgeManager {
 
         // If there is an active workspace, update the deployment templates
         // with the desired runtime version
-        if (Utility.checkWorkspace()) {
+        if (Utility.checkWorkspace() !== undefined) {
             await this.updateRuntimeVersionInDeploymentTemplate();
         }
     }

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -59,7 +59,7 @@ export class EdgeManager {
     }
 
     public async addModuleForSolution(outputChannel: vscode.OutputChannel, templateUri?: vscode.Uri): Promise<void> {
-        const pattern = `{${Constants.deploymentTsonPattern}}`;
+        const pattern = `{${Constants.deploymentJsonPattern}}`;
         let templateFile: string = await Utility.getInputFilePath(templateUri,
             pattern,
             Constants.deploymentTemplateDesc,
@@ -394,7 +394,7 @@ export class EdgeManager {
     }
 
     private async updateRuntimeVersionInDeploymentTemplate() {
-        const pattern = `{${Constants.deploymentTsonPattern}}`;
+        const pattern = `{${Constants.deploymentJsonPattern}}`;
         const description = `${Constants.deploymentTemplateDesc}`;
 
         const fileList: vscode.Uri[] = await vscode.workspace.findFiles(pattern);

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -164,13 +164,13 @@ export class EdgeManager {
         }
 
         TelemetryClient.sendEvent(`${Constants.selectEdgeRuntimeVerEvent}`, {
-            template: edgeVersionPick
+            template: edgeVersionPick,
         });
 
         await Configuration.setWorkspaceConfigurationProperty(Constants.versionDefaultEdgeRuntime, edgeVersionPick);
         outputChannel.appendLine(`Default Azure IoT Edge Runtime is ${edgeVersionPick} now.`);
 
-        // If there is an active workspace, update the deployment templates 
+        // If there is an active workspace, update the deployment templates
         // with the desired runtime version
         if (Utility.checkWorkspace()) {
             await this.updateRuntimeVersionInDeploymentTemplate();
@@ -406,13 +406,13 @@ export class EdgeManager {
         const versionMap = Versions.getRunTimeVersionMap();
         for (const deploymentTemplateFile of fileList) {
             const deploymentTemplateFilePath: string = deploymentTemplateFile.fsPath;
-            let templateJson = await fse.readJson(deploymentTemplateFilePath);            
+            const templateJson = await fse.readJson(deploymentTemplateFilePath);
 
-            Versions.updateEdgeAgentImageVersion(templateJson, versionMap);
-            Versions.updateEdgeHubImageVersion(templateJson, versionMap);
+            Versions.updateSystemModuleImageVersion(templateJson, "edgeAgent", versionMap);
+            Versions.updateSystemModuleImageVersion(templateJson, "edgeHub", versionMap);
 
-            await fse.writeFile(deploymentTemplateFilePath, JSON.stringify(templateJson, null, 2), { encoding: "utf8" });            
-        };
+            await fse.writeFile(deploymentTemplateFilePath, JSON.stringify(templateJson, null, 2), { encoding: "utf8" });
+        }
     }
 
     private async addModuleToDeploymentTemplate(templateJson: any, templateFile: string, envFilePath: string,

--- a/src/edge/simulator.ts
+++ b/src/edge/simulator.ts
@@ -159,7 +159,7 @@ export class Simulator {
             const inputs = await this.inputInputNames();
             const imgVersion = Versions.edgeHubVersion();
             await this.setModuleCred(outputChannel);
-            await Executor.runInTerminal(Simulator.adjustTerminalCommand(this.getAdjustedSimulatorExecutorPath() + ` start -img "${imgVersion}" -i "${inputs}"`));
+            await Executor.runInTerminal(Simulator.adjustTerminalCommand(this.getAdjustedSimulatorExecutorPath() + ` start -er "${imgVersion}" -i "${inputs}"`));
         });
     }
 

--- a/src/edge/simulator.ts
+++ b/src/edge/simulator.ts
@@ -20,6 +20,7 @@ import { SimulatorInfo } from "../common/SimulatorInfo";
 import { TelemetryClient } from "../common/telemetryClient";
 import { UserCancelledError } from "../common/UserCancelledError";
 import { Utility } from "../common/utility";
+import { Versions } from "../common/version";
 import { IDeviceItem } from "../typings/IDeviceItem";
 import { InstallResult, InstallReturn } from "./InstallResult";
 
@@ -156,8 +157,9 @@ export class Simulator {
         return await this.callWithInstallationCheck(outputChannel, async () => {
             await this.checkIoTedgehubdevConnectionString(outputChannel);
             const inputs = await this.inputInputNames();
+            const imgVersion = Versions.edgeHubVersion();
             await this.setModuleCred(outputChannel);
-            await Executor.runInTerminal(Simulator.adjustTerminalCommand(this.getAdjustedSimulatorExecutorPath() + ` start -i "${inputs}"`));
+            await Executor.runInTerminal(Simulator.adjustTerminalCommand(this.getAdjustedSimulatorExecutorPath() + ` start -img "${imgVersion}" -i "${inputs}"`));
         });
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,7 +183,7 @@ export function activate(context: vscode.ExtensionContext) {
             const document = vscode.window && vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document : null;
             return configDiagnosticProvider.updateDiagnostics(document, diagCollection);
         });
-    
+
     initCommandAsync(context, outputChannel,
         "azure-iot-edge.showGallery",
         async (): Promise<void> => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,6 +177,14 @@ export function activate(context: vscode.ExtensionContext) {
         });
 
     initCommandAsync(context, outputChannel,
+        "azure-iot-edge.setDefaultEdgeRuntimeVersion",
+        async (): Promise<void> => {
+            await edgeManager.selectDefaultEdgeRuntimeVersion(outputChannel);
+            const document = vscode.window && vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document : null;
+            return configDiagnosticProvider.updateDiagnostics(document, diagCollection);
+        });
+    
+    initCommandAsync(context, outputChannel,
         "azure-iot-edge.showGallery",
         async (): Promise<void> => {
           return gallery.loadWebView();


### PR DESCRIPTION
When there is an active workspace, user can select which version of Edge Runtime is used. Default is 1.0 for both Edge agent and Edge hub.

To switch from the default, open the VSCode palette and select "Select Azure IoT Edge Solution Default Platform". The list of option right now is 1.0 and 1.1. Once the new version is selected, the existing modules in the workspace will have their deployment.json files updated and any new modules will use the last set desired Edge Runtime version.

The desired Edge Runtime version is used by simulator as well, in both solution and single module modes.