### PR TITLE
VSCode Edge extension install a custom version of simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## 1.24.1 - 2021-6-4
+### Changed
+* Allow user to specify the version of iotedgehubdev through IOTEDGEHUBDEV_VERSION environment variable
+
 ## 1.24.0 - 2021-3-26
 ### Changed
 * Allow user to select Edge Runtime version between 1.0 and 1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-edge",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3450,9 +3450,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -5243,9 +5243,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -5729,9 +5729,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-edge",
   "displayName": "Azure IoT Edge",
   "description": "This extension is now a part of Azure IoT Tools extension pack. We highly recommend installing Azure IoT Tools to get full capabilities for Azure IoT development. Develop, deploy, debug, and manage your IoT Edge solution.",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "publisher": "vsciot-vscode",
   "aiKey": "95b20d64-f54f-4de3-8ad5-165a75a6c6fe",
   "icon": "logo.png",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -187,7 +187,7 @@ export class Constants {
     public static failedInstallSimulator = "Failed to install 'iotedgehubdev' tool because of error:";
     public static outputNoSimulatorMsg = "Cannot execute command since 'iotedgehubdev' is not installed. Please install it first for IoT Edge Simulator.";
     public static outputSimulatorIsInstallingMsg = "'iotedgehubdev' is being installed now, and please wait for the installation.";
-    public static downloadingAndInstallingStandaloneSimulatorMsg = "Downloading and installing Azure IoT EdgeHub Dev Tool (iotedgehubdev)...";
+    public static downloadingAndInstallingStandaloneSimulatorMsg = "Downloading and installing Azure IoT EdgeHub Dev Tool (iotedgehubdev) version ";
     public static installStandaloneSimulatorFailedMsg = "Failed to install 'iotedgehubdev' tool, please check the output channel (Azure IoT Edge) for detailed error message.";
     public static unexpectedErrorWhenValidateSimulatorUpdate = "Unexpected errors occur when install / update 'iotedgehubdev': ";
     public static installManuallyMsg = "Please install 'iotedgehubdev' tool first for IoT Edge Simulator.";

--- a/src/edge/edgeManager.ts
+++ b/src/edge/edgeManager.ts
@@ -531,7 +531,7 @@ export class EdgeManager {
                 }
             case Constants.LANGUAGE_PYTHON:
                 try {
-                    await new Promise((resolve, reject) => {
+                    await new Promise<void>((resolve, reject) => {
                         tmp.dir({ unsafeCleanup: true }, (err, tmpDir, cleanupCallback) => {
                             if (err) {
                                 reject(err);
@@ -584,7 +584,7 @@ export class EdgeManager {
                 }
             case Constants.LANGUAGE_C:
                 try {
-                    await new Promise((resolve, reject) => {
+                    await new Promise<void>((resolve, reject) => {
                         download(`github:Azure/azure-iot-edge-c-module#${Versions.cTemplateVersion()}`, path.join(parent, name), (err) => {
                             if (err) {
                                 reject(err);

--- a/src/edge/simulator.ts
+++ b/src/edge/simulator.ts
@@ -221,6 +221,9 @@ export class Simulator {
                     if (releases.hasOwnProperty(lockVersion)){
                         version = lockVersion;
                     }
+                    else {
+                        outputChannel.appendLine(`The specified iotedgehubdev version ${version} is not a valid release`);
+                    }
                   }
                   outputChannel.appendLine(`The specified iotedgehubdev version is: ${version}`);
                 const standaloneDownloadUrl = `https://github.com/Azure/iotedgehubdev/releases/download/v${version}/iotedgehubdev-v${version}-win32-ia32.zip`;

--- a/src/edge/simulator.ts
+++ b/src/edge/simulator.ts
@@ -215,10 +215,12 @@ export class Simulator {
                 let version = Simulator.iotedgehubdevDefaultVersion;
                 const pipResponse = await request.get(Simulator.iotedgehubdevVersionUrl);
                 const releases = JSON.parse(pipResponse).releases;
-                let lockVersionExists = releases.includes(version);                
                 let lockVersion = process.env[Simulator.iotedgehubdevLockVersionKey];
-                if (lockVersion !== undefined && lockVersion.trim() !== "" && lockVersionExists == true) {
-                    version = lockVersion;
+                if (lockVersion !== undefined && lockVersion.trim() !== "") {
+                    // Make sure the custom version is an existing release
+                    if (releases.hasOwnProperty(lockVersion)){
+                        version = lockVersion;
+                    }
                   }
                   outputChannel.appendLine(`The specified iotedgehubdev version is: ${version}`);
                 const standaloneDownloadUrl = `https://github.com/Azure/iotedgehubdev/releases/download/v${version}/iotedgehubdev-v${version}-win32-ia32.zip`;

--- a/src/edge/simulator.ts
+++ b/src/edge/simulator.ts
@@ -32,6 +32,8 @@ enum SimulatorType {
 
 export class Simulator {
     private static iotedgehubdevVersionUrl: string = "https://pypi.org/pypi/iotedgehubdev/json";
+    private static iotedgehubdevLockVersionKey = "IOTEDGEHUBDEV_VERSION";
+    private static iotedgehubdevDefaultVersion = "0.14.8";
     private static learnMoreUrl: string = "https://aka.ms/AA3nuw8";
     private static simulatorVersionKey: string = "SimulatorVersion";
     private static simulatorExecutableName = "iotedgehubdev";
@@ -69,7 +71,7 @@ export class Simulator {
     }
 
     private isInstalling: boolean = false;
-    private latestSimulatorInfo: SimulatorInfo;
+    private desiredSimulatorInfo: SimulatorInfo;
     private simulatorExecutablePath: string;
 
     constructor(private context: vscode.ExtensionContext) {
@@ -95,9 +97,9 @@ export class Simulator {
             } else {
                 const version: string | null = await this.getCurrentSimulatorVersion();
                 if (version && semver.valid(version)) {
-                    const latestVersion: string | undefined = await this.getLatestSimulatorVersion(outputChannel);
-                    if (latestVersion && semver.gt(latestVersion, version)) {
-                        message = `${Constants.updateSimulatorMsg} (${version} to ${latestVersion})`;
+                    const desiredVersion: string | undefined = await this.getDesiredSimulatorVersion(outputChannel);
+                    if (desiredVersion && semver.neq(desiredVersion, version)) {
+                        message = `${Constants.updateSimulatorMsg} (${version} to ${desiredVersion})`;
                     } else {
                         return;
                     }
@@ -207,24 +209,31 @@ export class Simulator {
         });
     }
 
-    private async getLastestSimulatorInfo(outputChannel: vscode.OutputChannel) {
-        if (!this.latestSimulatorInfo) {
+    private async getDesiredSimulatorInfo(outputChannel: vscode.OutputChannel) {
+        if (!this.desiredSimulatorInfo) {
             await RetryPolicy.retry(Simulator.maxRetryTimes, Simulator.retryInterval, outputChannel, async () => {
+                let version = Simulator.iotedgehubdevDefaultVersion;
                 const pipResponse = await request.get(Simulator.iotedgehubdevVersionUrl);
-                const version = JSON.parse(pipResponse).info.version;
+                const releases = JSON.parse(pipResponse).releases;
+                let lockVersionExists = releases.includes(version);                
+                let lockVersion = process.env[Simulator.iotedgehubdevLockVersionKey];
+                if (lockVersion !== undefined && lockVersion.trim() !== "" && lockVersionExists == true) {
+                    version = lockVersion;
+                  }
+                  outputChannel.appendLine(`The specified iotedgehubdev version is: ${version}`);
                 const standaloneDownloadUrl = `https://github.com/Azure/iotedgehubdev/releases/download/v${version}/iotedgehubdev-v${version}-win32-ia32.zip`;
-                this.latestSimulatorInfo = new SimulatorInfo(version, standaloneDownloadUrl);
+                this.desiredSimulatorInfo = new SimulatorInfo(version, standaloneDownloadUrl);
             });
 
-            return this.latestSimulatorInfo;
+            return this.desiredSimulatorInfo;
         } else {
-            return this.latestSimulatorInfo;
+            return this.desiredSimulatorInfo;
         }
     }
 
-    private async getLatestSimulatorVersion(outputChannel: vscode.OutputChannel): Promise<string | undefined> {
+    private async getDesiredSimulatorVersion(outputChannel: vscode.OutputChannel): Promise<string | undefined> {
         try {
-            const info: SimulatorInfo = await this.getLastestSimulatorInfo(outputChannel);
+            const info: SimulatorInfo = await this.getDesiredSimulatorInfo(outputChannel);
             return info.version;
         } catch (error) {
             return undefined;
@@ -262,21 +271,24 @@ export class Simulator {
     }
 
     private async downloadStandaloneSimulatorWithProgress(outputChannel: vscode.OutputChannel) {
+        const info: SimulatorInfo = await this.getDesiredSimulatorInfo(outputChannel);        
+        const version: string = info.version;
+
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: Constants.downloadingAndInstallingStandaloneSimulatorMsg,
+            title: Constants.downloadingAndInstallingStandaloneSimulatorMsg + version,
         }, async () => {
             await this.downloadStandaloneSimulator(outputChannel);
         });
     }
 
     private async downloadStandaloneSimulator(outputChannel: vscode.OutputChannel) {
-        const info: SimulatorInfo = await this.getLastestSimulatorInfo(outputChannel);
+        const info: SimulatorInfo = await this.getDesiredSimulatorInfo(outputChannel);
         const binariesZipUrl: string = info.standaloneDownloadUrl;
         const version: string = info.version;
 
         await RetryPolicy.retry(Simulator.maxRetryTimes, Simulator.retryInterval, outputChannel, async () => {
-            await new Promise((resolve, reject) => {
+            await new Promise<void>((resolve, reject) => {
                 const req = request(binariesZipUrl);
                 req.on("response",  (res) => {
                     if (res.statusCode === 200) {


### PR DESCRIPTION
With this change VSCode Edge extension will install a custom version of iotedgehubdev specified through IOTEDGEHUBDEV_VERSION.

The change was validated in these scenarios:
IOTEDGEHUBDEV_VERSION < current version
IOTEDGEHUBDEV_VERSION > current version
iotedgehubdev is not installed
IOTEDGEHUBDEV_VERSION == current version
IOTEDGEHUBDEV_VERSION is not a valid release
no IOTEDGEHUBDEV_VERSION is specified