### PR TITLE
Increment version of extension to rerun package and publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 install:
 - npm install
 - npm install -g vsce
+- npm list -g vsce
 script:
 - npm run tslint
 - npm run compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## 1.24.2 - 2021-7-15
+### Changed
+* Enumerate vsce version in release pipeline
+
 ## 1.24.1 - 2021-6-4
 ### Changed
 * Allow user to specify the version of iotedgehubdev through IOTEDGEHUBDEV_VERSION environment variable

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-edge",
   "displayName": "Azure IoT Edge",
   "description": "This extension is now a part of Azure IoT Tools extension pack. We highly recommend installing Azure IoT Tools to get full capabilities for Azure IoT development. Develop, deploy, debug, and manage your IoT Edge solution.",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "publisher": "vsciot-vscode",
   "aiKey": "95b20d64-f54f-4de3-8ad5-165a75a6c6fe",
   "icon": "logo.png",


### PR DESCRIPTION
There was an issue with packaging the extension and there is no way to unpublish a version that is already published thus incrementing and republishing.

https://github.com/microsoft/vscode-azure-iot-edge/issues/583